### PR TITLE
Introduce `readAs` for whole datasets

### DIFF
--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -26,6 +26,7 @@ task test, "Runs all tests":
   exec "nim c -r tests/tnested.nim"
   exec "nim c -r tests/tfilter.nim"
   exec "nim c -r tests/toverwrite.nim"
+  exec "nim c -r tests/tconvert.nim"
   # regression tests
   exec "nim c -r tests/tint64_dset.nim"
   exec "nim c -r tests/t17.nim"

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -132,7 +132,6 @@ proc delete*[T](h5o: T, name: string): bool =
   ## a relative name is valid. Else if `h5o` is the file itself, `name` needs
   ## to be the full path. Returns `true` if deletion successful
   let h5id = getH5Id(h5o)
-
   result = if H5Ldelete(h5id, name, H5P_DEFAULT) >= 0: true else: false
 
 proc copy*[T](h5in: var H5FileObj, h5o: T,

--- a/tests/tconvert.nim
+++ b/tests/tconvert.nim
@@ -1,0 +1,56 @@
+import nimhdf5
+import sequtils
+import os
+import ospaths
+import typeinfo
+
+const
+  File = "tests/dset.h5"
+  DsetName = "/group/dset"
+var d_ar = @[ @[1, 2, 3, 4, 5],
+              @[6, 7, 8, 9, 10] ]
+
+
+proc create_dset(h5f: var H5FileObj): H5DataSet =
+  result = h5f.create_dataset(DsetName, (2, 5), int)
+  result[result.all] = d_ar
+
+when isMainModule:
+  # open file, create dataset
+  var
+    h5f = H5File(File, "rw")
+    dset = h5f.create_dset()
+
+  # now read data as a different data type
+  template assertType(t: untyped): untyped =
+    let dConvert = dset.readAs(t).reshape([2, 5])
+    doAssert type(dConvert[0][0]) is t
+    for i, a in d_ar:
+      for j, b in d_ar:
+        doAssert t(d_ar[i][j]) == dConvert[i][j]
+    # now via `h5f` instead of `dset`
+    let dFromFile = h5f.readAs(DsetName, t).reshape([2, 5])
+    doAssert dConvert == dFromFile
+
+    # now the same for a subset
+    let dIdxs = dset.readAs(@[0, 1], t)
+    # NOTE: indices due to broadcastingg of indices given to `readAs`
+    doAssert dIdxs[0] == t(d_ar[0][0])
+    doAssert dIdxs[1] == t(d_ar[1][1])
+
+  assertType(int8)
+  assertType(int16)
+  assertType(int32)
+  assertType(int64)
+  assertType(uint8)
+  assertType(uint16)
+  assertType(uint32)
+  assertType(uint64)
+  assertType(float32)
+  assertType(float64)
+
+  var err = h5f.close()
+  doAssert(err >= 0)
+
+  # clean up after ourselves
+  removeFile(File)


### PR DESCRIPTION
Adds a `readAs` proc which allows reading and converting of a whole
dataset instead of just individual indices, without having to get the
`conversion` proc manually.

Allows an overload working on H5FileObj given.

`readConvert` for individual indices if deprecated in favor of the
simpler `readAs` name.