### PR TITLE
Test case for group / dataset deletion, closes #5

### DIFF
--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -27,6 +27,7 @@ task test, "Runs all tests":
   exec "nim c -r tests/tfilter.nim"
   exec "nim c -r tests/toverwrite.nim"
   exec "nim c -r tests/tconvert.nim"
+  exec "nim c -r tests/tdelete.nim"
   # regression tests
   exec "nim c -r tests/tint64_dset.nim"
   exec "nim c -r tests/t17.nim"

--- a/tests/tdelete.nim
+++ b/tests/tdelete.nim
@@ -1,0 +1,58 @@
+import nimhdf5
+import sequtils
+import os
+import ospaths
+import typeinfo
+
+const
+  File = "tests/dset.h5"
+  DsetName1 = "/group/dset"
+  DsetName2 = "/group2/dset"
+  DsetName3 = "/group3/dset"
+var d_ar = @[ @[1, 2, 3, 4, 5],
+              @[6, 7, 8, 9, 10] ]
+
+proc create_dset(h5f: var H5FileObj, name: string): H5DataSet =
+  result = h5f.create_dataset(name, (2, 5), int)
+  result[result.all] = d_ar
+
+when isMainModule:
+  # open file, create dataset
+  var
+    h5f = H5File(File, "rw")
+    dset1 = h5f.create_dset(DsetName1)
+    dset2 = h5f.create_dset(DsetName2)
+    dset3 = h5f.create_dset(DsetName3)
+
+  # check groups and datasets exist
+  doAssert "group" in h5f
+  doAssert "group2" in h5f
+  doAssert "group3" in h5f
+  doAssert "group/dset" in h5f
+  doAssert "group2/dset" in h5f
+  doAssert "group3/dset" in h5f
+
+  # now delete
+  # first delete only dset then group
+  doAssert h5f.delete("group/dset")
+  doAssert "group/dset" notin h5f
+  doAssert h5f.delete("group")
+  doAssert "group" notin h5f
+
+  # now delete group2 and its contents
+  doAssert h5f.delete("group2")
+  doAssert "group2" notin h5f
+  doAssert "group2/dset" notin h5f
+
+  # finally delete group3/dset from relative group3
+  var grp3 = h5f["group3".grp_str]
+  doAssert grp3.delete("dset")
+  doAssert "group3/dset" notin h5f
+  doAssert h5f.delete("group3")
+  doAssert "group3" notin h5f
+
+  var err = h5f.close()
+  doAssert(err >= 0)
+
+  # clean up after ourselves
+  removeFile(File)


### PR DESCRIPTION
This adds a test case for deletion of groups and datasets.

While adding the test case a bug was found. `existsInFile` previously only checked for the whole path given. But the docs for `H5Lexists`, which is called internally, explicitly states the user is responsible for checking iteratively, if a nested path exists. The call fails if a parent does not exist.
https://support.hdfgroup.org/HDF5/doc/RM/RM_H5L.html#Link-Exists