### PR TITLE
Add `add` proc to resize chunked storage by adding data to it

### DIFF
--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -28,6 +28,7 @@ task test, "Runs all tests":
   exec "nim c -r tests/toverwrite.nim"
   exec "nim c -r tests/tconvert.nim"
   exec "nim c -r tests/tdelete.nim"
+  exec "nim c -r tests/tresize_by_add.nim"
   # regression tests
   exec "nim c -r tests/tint64_dset.nim"
   exec "nim c -r tests/t17.nim"

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -245,29 +245,8 @@ proc parseShapeTuple[T: tuple](dims: T): seq[int] =
   ##    seq[int] = seq of int of length len(dims), containing
   ##            the size of each dimension of dset
   ##            Note: H5File needs to be aware of that size!
-  # NOTE: previously we returned a seq[hsize_t], but we now perform the
-  # conversion from int to hsize_t in simple_dataspace() (which is the
-  # only place we use the result of this proc!)
-  # TODO: move the when T is int: branch from create_dataset to here
-  # to clean up create_dataset!
-
-  var n_dims: int
-  # count the number of fields in the array, since that is number
-  # of dimensions we have
-  for field in dims.fields:
-    inc n_dims
-
-  result = newSeq[int](n_dims)
-  # now set the elements of result to the values in the tuple
-  var count: int = 0
   for el in dims.fields:
-    # now set the value of each dimension
-    # enter the shape in reverse order, since H5 expects data in other notation
-    # as we do in Nim
-    #result[^(count + 1)] = hsize_t(el)
-    result[count] = int(el)
-    inc count
-
+    result.add int(el)
 
 proc parseChunkSizeAndMaxShape(dset: var H5DataSet, chunksize, maxshape: seq[int]): hid_t =
   ## proc to parse the chunk size and maxhshape arguments handed to the create_dataset()

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -1304,11 +1304,11 @@ proc `[]`*[T](h5f: var H5FileObj, name: string, t: hid_t, dtype: typedesc[T]):
   let dset = h5f.get(name.dset_str)
   result = dset[t, dtype]
 
-proc resize*[T: tuple](dset: var H5DataSet, shape: T) =
+proc resize*[T: tuple | seq](dset: var H5DataSet, shape: T) =
   ## proc to resize the dataset to the new size given by `shape`
   ## inputs:
   ##     dset: var H5DataSet = dataset to be resized
-  ##     shape: T = tuple describing the new size of the dataset
+  ##     shape: T = tuple or seq describing the new size of the dataset
   ## Keep in mind:
   ##   - resizing only possible for datasets using chunked storage
   ##     (created with chunksize / maxshape != @[])
@@ -1320,7 +1320,10 @@ proc resize*[T: tuple](dset: var H5DataSet, shape: T) =
 
   # check if dataset is chunked storage
   if H5Pget_layout(dset.dcpl_id) == H5D_CHUNKED:
-    var newshape = mapIt(parseShapeTuple(shape), hsize_t(it))
+    when T is tuple:
+      var newshape = mapIt(parseShapeTuple(shape), hsize_t(it))
+    elif T is seq:
+      var newshape = shape.mapIt(hsize_t(it))
     # before we resize the dataspace, we get a copy of the
     # dataspace, since this internally refreshes the dataset. Important
     # since the dataset might be opened for reading when this

--- a/tests/tresize_by_add.nim
+++ b/tests/tresize_by_add.nim
@@ -8,14 +8,22 @@ const
   File = "tests/dset.h5"
   DsetName = "/toAdd"
   DsetName2 = "/toAdd2"
+  DsetVlen = "/toAddVlen"
 
 var d_ar = @[ @[1, 1, 1],
               @[1, 1, 1],
               @[1, 1, 1] ]
+var vlenData = @[ @[1, 2],
+                  @[3, 4, 5] ]
 
 proc create_dset(h5f: var H5FileObj, name: string): H5DataSet =
   result = h5f.create_dataset(name, (3, 3), int, chunksize = @[3, 3], maxshape = @[int.high, 6])
   result[result.all] = d_ar
+
+proc create_vlen(h5f: var H5FileObj, name: string): H5DataSet =
+  let vlent = special_type(int)
+  result = h5f.create_dataset(name, (2, 1), vlent, chunksize = @[2, 1], maxshape = @[4, 1])
+  result[result.all] = vlenData
 
 when isMainModule:
   # open file, create dataset
@@ -23,6 +31,7 @@ when isMainModule:
     h5f = H5File(File, "rw")
     dset = h5f.create_dset(DsetName)
     dset2 = h5f.create_dset(DsetName2)
+    dsetV = h5f.create_vlen(DsetVlen)
 
   dset.add d_ar
   doAssert dset.shape == @[6, 3]
@@ -34,6 +43,16 @@ when isMainModule:
   except ImmutableDatasetError:
     discard
   doAssert dset2.shape == @[3, 6]
+
+  # now check adding also works for variable length data
+  doAssert dsetV.shape == @[2, 1]
+  dsetV.add vlenData
+  doAssert dsetV.shape == @[4, 1]
+  try:
+    dsetV.add vlenData
+  except ImmutableDatasetError:
+    discard
+  doAssert dsetV.shape == @[4, 1]
 
   let err = h5f.close()
   assert(err >= 0)

--- a/tests/tresize_by_add.nim
+++ b/tests/tresize_by_add.nim
@@ -1,0 +1,42 @@
+import nimhdf5
+import sequtils
+import os
+import ospaths
+import typeinfo
+
+const
+  File = "tests/dset.h5"
+  DsetName = "/toAdd"
+  DsetName2 = "/toAdd2"
+
+var d_ar = @[ @[1, 1, 1],
+              @[1, 1, 1],
+              @[1, 1, 1] ]
+
+proc create_dset(h5f: var H5FileObj, name: string): H5DataSet =
+  result = h5f.create_dataset(name, (3, 3), int, chunksize = @[3, 3], maxshape = @[int.high, 6])
+  result[result.all] = d_ar
+
+when isMainModule:
+  # open file, create dataset
+  var
+    h5f = H5File(File, "rw")
+    dset = h5f.create_dset(DsetName)
+    dset2 = h5f.create_dset(DsetName2)
+
+  dset.add d_ar
+  doAssert dset.shape == @[6, 3]
+  dset2.add(d_ar, axis = 1)
+  doAssert dset2.shape == @[3, 6]
+  # check that adding again to axis = 1 of dset2 will fail
+  try:
+    dset2.add(d_ar, axis = 1)
+  except ImmutableDatasetError:
+    discard
+  doAssert dset2.shape == @[3, 6]
+
+  let err = h5f.close()
+  assert(err >= 0)
+
+  # clean up after ourselves
+  removeFile(File)


### PR DESCRIPTION
The new `add` proc allows automatic resizing and writing of data along a given axis.
It's basically a wrapper around checking dimensions, resizing and writing data to the resized portion via hyperslab writing.

For now this only works when the dataset is chunked. For small enough datasets we can easily remove a non-chunked dataset after reading it to memory to rewrite it again as a chunked storage. This is not implemented yet though.