### PR TITLE
make all objects `ref objects`, add attribute JSON iterator

### DIFF
--- a/README.org
+++ b/README.org
@@ -163,9 +163,6 @@ features and their usage.
 The high level bindings come with several quirks which are good to
 know.
 
-- an annoying bug, because of a conversion of datatype names from their
-  name without to their name with size attached, can cause a
-  =ValueError= to be raised (see issue #9)
 - when reading back a dataset with dimension > 1, the returned data is
   returned in a flat =seq=, instead of e.g. a nested
   =seq[seq[<type>]]= as one might expect.
@@ -175,10 +172,6 @@ know.
   The exception is variable length data in case of a 1D dataset
   containing seqs of varying sizes. Here a nested seq of the correct
   elements is returned.
-- a large fraction of all procs currently rely on a mutable object
-  to keep track of the corresponding objects in the H5
-  library. However, there are quite a few procs which could work just
-  fine on a constant object (see issue #10).
 - when grabbing a group or dataset from a H5FileObj via =[](name:
   string)=, a conversion of the string to a distinct =string= type
   =grp_str= or =dset_str= is used to provide a uniform interface for

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.15"
+version       = "0.3.0"
 author        = "Sebastian Schmidt"
 description   = "Bindings for the HDF5 data format C library"
 license       = "MIT"
@@ -10,7 +10,7 @@ skipExt       = @["nim~"]
 
 # Dependencies
 
-requires "nim >= 0.18.0"
+requires "nim >= 1.0.0"
 requires "https://github.com/vindaar/seqmath#head"
 
 task test, "Runs all tests":

--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -13,7 +13,6 @@ import hdf5_wrapper
 import H5nimtypes
 import datatypes
 import dataspaces
-import h5util
 import util
 
 # forward declare procs, which we need to read the attributes from file

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -345,7 +345,7 @@ proc create_dataset_in_file(h5file_id: hid_t, dset: H5DataSet): hid_t =
                          H5P_DEFAULT, dset.dcpl_id, H5P_DEFAULT)
 
 proc create_dataset*[T: (tuple | int | seq)](
-    h5f: var H5FileObj,
+    h5f: H5FileObj,
     dset_raw: string,
     shape_raw: T,
     dtype: (typedesc | hid_t),
@@ -516,7 +516,7 @@ proc create_dataset*[T: (tuple | int | seq)](
   result = dset
 
 proc create_dataset*[T: (tuple | int | seq)](
-    h5f: var H5FileObj,
+    h5f: H5FileObj,
     dset_raw: string,
     shape_raw: T,
     dtype: (typedesc | hid_t),

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -32,33 +32,26 @@ type
   H5Attributes* = ref object
     # attr_tab is a table containing names and corresponding
     # H5 info
-    attr_tab*: ref Table[string, ref H5Attr]
+    attr_tab*: TableRef[string, H5Attr]
     num_attrs*: int
     parent_name*: string
     parent_id*: hid_t
     parent_type*: string
 
-  # a tuple which stores information about a single attribute
-  H5Attr* = tuple[
-    opened: bool, # flag which indicates whether attribute is opened
-    attr_id: hid_t,
-    dtype_c: hid_t,
-    dtypeAnyKind: AnyKind,
+  # stores information about a single attribute
+  H5Attr* = ref object
+    opened*: bool # flag which indicates whether attribute is opened
+    attr_id*: hid_t
+    dtype_c*: hid_t
+    dtypeAnyKind*: AnyKind
     # BaseKind contains the type within a (nested) seq iff
     # dtypeAnyKind is akSequence
-    dtypeBaseKind: AnyKind,
-    attr_dspace_id: hid_t]
-
-
-  # not used atm
-  H5Object = object of RootObj
-    name*: string
-    parent*: string
-    parent_id*: hid_t
+    dtypeBaseKind*: AnyKind
+    attr_dspace_id*: hid_t
 
   # an object to store information about a hdf5 dataset. It is a combination of
   # an HDF5 dataspace and dataset id (contains both of them)
-  H5DataSet* = object #of H5Object
+  H5DataSet* = ref object
     name*: string
     # we store the shape information internally as a seq, so that we do
     # not have to know about it at compile time
@@ -106,7 +99,7 @@ type
     dcpl_id*: hid_t
 
   # an object to store information about a HDF5 group
-  H5Group* = object #of H5Object
+  H5Group* = ref object
     name*: string
     # # parent string, which contains the name of the group in which the
     # # dataset is located
@@ -120,7 +113,7 @@ type
     # reference to the file object, in which group resides. Important to perform checks
     # in procs, which should not depend explicitly on H5FileObj, but necessarily depend
     # implicitly on it, e.g. create_group, iterator items etc.
-    file_ref*: ref H5FileObj
+    file_ref*: H5FileObj
     # the id of the HDF5 group (its location id)
     group_id*: hid_t
     # TODO: think, should H5Group contain a table about its dataspaces? Or should
@@ -129,9 +122,9 @@ type
     # However: then H5FileObj needs to still know (!) about its dataspaces and where
     # they are located. Easily done by keeping a table of string of each dataset, which
     # contains their location simply by the path and have a table of H5Group objects
-    datasets*: ref Table[string, ref H5DataSet]
+    datasets*: TableRef[string, H5DataSet]
     # each group may have subgroups itself, keep table of these
-    groups*: ref Table[string, ref H5Group]
+    groups*: TableRef[string, H5Group]
     # attr stores information about attributes
     attrs*: H5Attributes
     # property list identifier, which stores information like "is chunked storage" etc.
@@ -140,9 +133,7 @@ type
     # here we store H5P_GROUP_CREATE property list
     gcpl_id*: hid_t
 
-
-
-  H5FileObj* = object #of H5Object
+  H5FileObj* = ref object
     name*: string
     # the file_id is the unique identifier of the opened file. Each
     # low level C call uses this file_id to idenfity the file to work
@@ -157,10 +148,10 @@ type
     # var to store status of C calls
     status*: hid_t
     # groups is a table, which stores the names of groups stored in the file
-    groups*: ref Table[string, ref H5Group]
+    groups*: TableRef[string, H5Group]
     # datasets is a table, which stores the names of datasets by string
     # while keeping the hid_t dataset_id as the value
-    datasets*: ref Table[string, ref H5DataSet]
+    datasets*: TableRef[string, H5DataSet]
     dataspaces*: Table[string, hid_t]
     # attr stores information about attributes
     attrs*: H5Attributes
@@ -171,8 +162,6 @@ type
     fapl_id*: hid_t
     # here we store H5P_FILE_CREATE property list
     fcpl_id*: hid_t
-
-
 
   # this exception is used in cases where all conditional cases are already thought
   # to be covered to annotate (hopefully!) unreachable branches

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -7,7 +7,6 @@ import hdf5_wrapper
 import H5nimtypes
 import util
 
-
 type
   # these distinct types provide the ability to distinguish the `[]` function
   # acting on H5FileObj between a dataset and a group, s.t. we can access groups
@@ -187,6 +186,21 @@ const
 
 # add an invalid rw code to handle wrong inputs in parseH5rw_type
 const H5F_INVALID_RW*    = cuint(0x00FF)
+
+template getH5Id*(h5o: typed): hid_t =
+  ## this template returns the correct location id of either
+  ## - a H5FileObj
+  ## - a H5DataSet
+  ## - a H5Group
+  ## given as `h5o`
+  # var result: hid_t = -1
+  when h5o is H5FileObj:
+    let result = h5o.file_id
+  elif h5o is H5DataSet:
+    let result = h5o.dataset_id
+  elif h5o is H5Group:
+    let result = h5o.group_id
+  result
 
 proc getTypeNoSize(x: AnyKind): AnyKind =
   ## returns the datatype without size information

--- a/src/nimhdf5/groups.nim
+++ b/src/nimhdf5/groups.nim
@@ -31,24 +31,6 @@ proc newH5Group*(name: string = ""): H5Group =
   result.groups = groups
   result.attrs = attrs
 
-proc `$`*(group: ref H5Group): string =
-  ## to string conversion for a `ref H5Group` for pretty printing
-  result = "\n{\n\t'name': " & group.name & "\n\t'parent': " & group.parent & "\n\t'parent_id': " & $group.parent_id
-  result = result & "\n\t'file': " & group.file & "\n\t'group_id': " & $group.group_id & "\n\t'datasets': " & $group.datasets
-  result = result & "\n\t'groups': {"
-  for k, v in group.groups:
-    result = result & "\n\t\t" & k
-  result = result & "\n\t}\n}"
-
-proc `$`*(group: H5Group): string =
-  ## to string conversion for a `H5Group` for pretty printing
-  result = "\n{\n\t'name': " & group.name & "\n\t'parent': " & group.parent & "\n\t'parent_id': " & $group.parent_id
-  result = result & "\n\t'file': " & group.file & "\n\t'group_id': " & $group.group_id & "\n\t'datasets': " & $group.datasets
-  result = result & "\n\t'groups': {"
-  for k, v in group.groups:
-    result = result & "\n\t\t" & k
-  result = result & "\n\t}\n}"
-
 proc flush*(group: H5Group, flushKind: FlushKind) =
   ## wrapper around H5Fflush for convenience
   var err: herr_t

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -102,7 +102,7 @@ proc firstExistingParent*[T](h5f: T, name: string): Option[H5Group] =
     # in this case we're not at the root, so check whether name exists
     let exists = hasKey(h5f.groups, name)
     if exists == true:
-      result = some(h5f.groups[name][])
+      result = some(h5f.groups[name])
     else:
       result = firstExistingParent(h5f, getParent(name))
   else:
@@ -140,7 +140,7 @@ proc getObjectTypeByName*(h5id: hid_t, name: string): H5O_type_t =
   else:
     raise newException(HDF5LibraryError, "Call to HDF5 library failed in `getObjectTypeByName`")
 
-proc contains*(h5f: var H5FileObj, name: string): bool =
+proc contains*(h5f: H5FileObj, name: string): bool =
   ## Faster version of `contains` below, simply making use of
   ## `H5Lexists` using `existsInFile`. Does not require us to
   ## traverse our tables
@@ -156,7 +156,7 @@ proc delete*[T](h5o: T, name: string): bool =
   let h5id = getH5Id(h5o)
   result = if H5Ldelete(h5id, name, H5P_DEFAULT) >= 0: true else: false
 
-proc copy*[T](h5in: var H5FileObj, h5o: T,
+proc copy*[T](h5in: H5FileObj, h5o: T,
               target: Option[string] = none[string](),
               h5out: Option[H5FileObj] = none[H5FileObj]()): bool =
   ## Copies the object `h5o` from `source` to `target`.

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -17,6 +17,29 @@ import H5nimtypes
 import util
 import datatypes
 
+import attributes
+
+import json
+func `%`(c: char): JsonNode = % $c # for `withAttr` returning a char
+iterator attrsJson*(attrs: H5Attributes): (string, JsonNode) =
+  ## yields all attribute keys and their values as `JsonNode`. This way
+  ## we can actually return all values to the user with one iterator.
+  ## And for attributes the variant object overhead does not matter anyways.
+  attrs.read_all_attributes
+  for key, attr in pairs(attrs.attr_tab):
+    attrs.withAttr(key):
+      yield (key, % attr)
+    discard attr.close()
+
+iterator attrsJson*[T: H5FileObj | H5Group | H5DataSet](h5o: T): (string, JsonNode) =
+  for key, val in attrsJson(h5o.attrs):
+    yield (key, val)
+
+proc attrsToJson*[T: H5Group | H5DataSet](h5o: T): JsonNode =
+  ## returns all attributes as a json node of kind `JObject`
+  result = newJObject()
+  for key, jval in h5o.attrsJson:
+    result[key] = jval
 
 proc pretty*(dset: H5DataSet, indent = 0, full = false): string =
   result = repeat(' ', indent) & "{\n"


### PR DESCRIPTION
From one of the commit messages:

```
This change was long overdue.

HDF5 objects track all sorts of internal state to keep track of the
objects within the HDF5 C libray. This means for a large number of
operations, which don't change the given object from a user
perspective a `var H5*` object still had to be available, which often
meant having to declare e.g. a group or dataset as `var` although
apparently nothing that changes the objet would take place,
e.g. reading a simple dataset.

With every object being a `ref object` we kind of circumvent this,
because the immutability of a `ref object` refers to the reference
itself and not the object the reference points to.

Also from a more abstract point of view this makes a whole lot more
sense. These objects are not objects stored in a H5 file, but are
just *references* to objects in a file. Thinking about immutability of
such objects when the HDF5 C library does all sorts of crazy stuff in
the backend is almost ridiculous.

Also the tables, which store the different subgroups and datasets are
now proper `TableRef` instead of `ref Table` fields.
Although the content of these still needs to be looked at again...
```

It also introduces `attrsJson` iterators for H5 objects and a `attrsToJson` proc. These yield / return the attribute keys and their values as `JsonNodes`. 