### PR TITLE
Fix copy attributes in certain circumstances

### DIFF
--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -19,10 +19,6 @@ import util
 proc read_all_attributes*(h5attr: H5Attributes)
 proc getNumAttrs(h5attr: H5Attributes): int
 
-proc `$`*(h5attr: H5Attr): string =
-  ## proc to define echo of H5Attr by echoing its contained object
-  result = $(h5attr)
-
 proc newH5Attributes*(): H5Attributes =
   let attr = newTable[string, H5Attr]()
   result = H5Attributes(attr_tab: attr,

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -44,23 +44,23 @@ proc attrsToJson*[T: H5Group | H5DataSet](h5o: T): JsonNode =
 proc pretty*(dset: H5DataSet, indent = 0, full = false): string =
   result = repeat(' ', indent) & "{\n"
   let fieldInd = repeat(' ', indent + 2)
-  result.add fieldInd & &"name: {dset.name},\n"
-  result.add fieldInd & &"file: {dset.file},\n"
-  result.add fieldInd & &"parent: {dset.parent},\n"
-  result.add fieldInd & &"shape: {dset.shape},\n"
-  result.add fieldInd & &"dtype: {dset.dtype},\n"
+  result.add &"{fieldInd}name: {dset.name},\n"
+  result.add &"{fieldInd}file: {dset.file},\n"
+  result.add &"{fieldInd}parent: {dset.parent},\n"
+  result.add &"{fieldInd}shape: {dset.shape},\n"
+  result.add &"{fieldInd}dtype: {dset.dtype}"
   if full:
-    result.add fieldInd & &"maxshape: {dset.maxshape},\n"
-    result.add fieldInd & &"parent_id: {dset.parent_id},\n"
-    result.add fieldInd & &"chunksize: {dset.chunksize},\n"
-    result.add fieldInd & &"dtypeAnyKind: {dset.dtypeAnyKind},\n"
-    result.add fieldInd & &"dtypeBaseKind: {dset.dtypeBaseKind},\n"
-    result.add fieldInd & &"dtype_c: {dset.dtype_c},\n"
-    result.add fieldInd & &"dtype_class: {dset.dtype_class},\n"
-    result.add fieldInd & &"dataset_id: {dset.dataset_id},\n"
-    result.add fieldInd & &"num_attrs: {dset.attrs.num_attrs},\n"
-    result.add fieldInd & &"dapl_id: {dset.dapl_id},\n"
-    result.add fieldInd & &"dcpl_id: {dset.dcpl_id},\n"
+    result.add &",\n{fieldInd}maxshape: {dset.maxshape},\n"
+    result.add &"{fieldInd}parent_id: {dset.parent_id},\n"
+    result.add &"{fieldInd}chunksize: {dset.chunksize},\n"
+    result.add &"{fieldInd}dtypeAnyKind: {dset.dtypeAnyKind},\n"
+    result.add &"{fieldInd}dtypeBaseKind: {dset.dtypeBaseKind},\n"
+    result.add &"{fieldInd}dtype_c: {dset.dtype_c},\n"
+    result.add &"{fieldInd}dtype_class: {dset.dtype_class},\n"
+    result.add &"{fieldInd}dataset_id: {dset.dataset_id},\n"
+    result.add &"{fieldInd}num_attrs: {dset.attrs.num_attrs},\n"
+    result.add &"{fieldInd}dapl_id: {dset.dapl_id},\n"
+    result.add &"{fieldInd}dcpl_id: {dset.dcpl_id}"
   result.add repeat(' ', indent) & "\n}"
 
 proc `$`*(dset: H5DataSet): string =
@@ -70,48 +70,63 @@ proc `$`*(dset: H5DataSet): string =
 proc pretty*(grp: H5Group, indent = 2, full = false): string =
   result = repeat(' ', indent) & "{\n"
   let fieldInd = repeat(' ', indent + 2)
-  result.add fieldInd & &"name: {grp.name},\n"
-  result.add fieldInd & &"file: {grp.file},\n"
-  result.add fieldInd & &"parent: {grp.parent},\n"
+  result.add &"{fieldInd}name: {grp.name},\n"
+  result.add &"{fieldInd}file: {grp.file},\n"
+  result.add &"{fieldInd}parent: {grp.parent}"
   if full:
-    result.add fieldInd & &"file_id: {grp.file_id},\n"
-    result.add fieldInd & &"group_id: {grp.group_id},\n"
-    result.add fieldInd & &"parent_id: {grp.parent_id},\n"
-    result.add fieldInd & &"gapl_id: {grp.gapl_id},\n"
-    result.add fieldInd & &"gcpl_id: {grp.gcpl_id},\n"
+    result.add &",\n{fieldInd}file_id: {grp.file_id},\n"
+    result.add &"{fieldInd}group_id: {grp.group_id},\n"
+    result.add &"{fieldInd}parent_id: {grp.parent_id},\n"
+    result.add &"{fieldInd}gapl_id: {grp.gapl_id},\n"
+    result.add &"{fieldInd}gcpl_id: {grp.gcpl_id}"
   if grp.datasets.len > 0:
-    result.add fieldInd & "datasets: {"
+    result.add &",\n{fieldInd}datasets: " & "{"
   for name, dset in grp.datasets:
-    result.add fieldInd & name & ": " & dset.pretty(indent = indent + 4)
+    result.add &"{fieldInd}{name}:  " & dset.pretty(indent = indent + 4)
   if grp.datasets.len > 0:
-    result.add fieldInd & "}"
+    result.add &"{fieldInd}" & "}"
   if grp.groups.len > 0:
-    result.add fieldInd & "groups: {"
+    result.add &",\n{fieldInd}groups: " & "{"
   for name, subgrp in grp.groups:
-    result.add fieldInd & name & ",\n"
+    result.add &"{fieldInd}{name},\n"
   if grp.groups.len > 0:
-    result.add fieldInd & "}"
+    result.add &"{fieldInd}" & "}"
   result.add repeat(' ', indent) & "\n}"
 
 proc `$`*(grp: H5Group): string =
   ## to string conversion for a `H5Group` for pretty printing
   result = pretty(grp, full = false)
 
+proc pretty*(att: H5Attr, indent = 0, full = false): string =
+  result = repeat(' ', indent) & "{\n"
+  let fieldInd = repeat(' ', indent + 2)
+  result.add &"{fieldInd}opened: {att.opened},\n"
+  result.add &"{fieldInd}dtypeAnyKind: {att.dtypeAnyKind}"
+  if full:
+    result.add &",\n{fieldInd}attr_id: {att.attr_id},\n"
+    result.add &"{fieldInd}dtype_c: {att.dtype_c},\n"
+    result.add &"{fieldInd}dtypeBaseKind: {att.dtypeBaseKind},\n"
+    result.add &"{fieldInd}attr_dspace_id: {att.attr_dspace_id}"
+  result.add repeat(' ', indent) & "\n}"
+
+proc `$`*(att: H5Attr): string =
+  result = pretty(att)
+
 proc pretty*(attrs: H5Attributes, indent = 2, full = false): string =
   ## For now this just prints the H5Attributes all as JSON
   result = repeat(' ', indent) & "{\n"
   let fieldInd = repeat(' ', indent + 2)
-  result.add fieldInd & &"num_attrs: {attrs.num_attrs},\n"
-  result.add fieldInd & &"parent_name: {attrs.parent_name},\n"
-  result.add fieldInd & &"parent_type: {attrs.parent_type},\n"
+  result.add &"{fieldInd}num_attrs: {attrs.num_attrs},\n"
+  result.add &"{fieldInd}parent_name: {attrs.parent_name},\n"
+  result.add &"{fieldInd}parent_type: {attrs.parent_type}"
   if full:
-    result.add fieldInd & &"parent_id: {attrs.parent_id},\n"
+    result.add &",\n{fieldInd}parent_id: {attrs.parent_id}"
   if attrs.num_attrs > 0:
-    result.add fieldInd & "attributes: {"
+    result.add &"{fieldInd}attributes: " & "{"
   for name, attr in attrs.attrsJson:
-    result.add fieldInd & name & &": {attr} ,\n"
+    result.add &"{fieldInd}{name}: {attr},\n"
   if attrs.num_attrs > 0:
-    result.add fieldInd & "}"
+    result.add &"{fieldInd}" & "}"
   result.add repeat(' ', indent) & "\n}"
 
 proc `$`*(attrs: H5Attributes): string =
@@ -121,26 +136,26 @@ proc `$`*(attrs: H5Attributes): string =
 proc pretty*(h5f: H5FileObj, indent = 2, full = false): string =
   result = repeat(' ', indent) & "{\n"
   let fieldInd = repeat(' ', indent + 2)
-  result.add fieldInd & &"name: {h5f.name},\n"
-  result.add fieldInd & &"rw_type: {h5f.rw_type},\n"
-  result.add fieldInd & &"visited: {h5f.visited},\n"
+  result.add &"{fieldInd}name: {h5f.name},\n"
+  result.add &"{fieldInd}rw_type: {h5f.rw_type},\n"
+  result.add &"{fieldInd}visited: {h5f.visited}"
   if full:
-    result.add fieldInd & &"file_id: {h5f.file_id},\n"
-    result.add fieldInd & &"err: {h5f.err},\n"
-    result.add fieldInd & &"status: {h5f.status},\n"
+    result.add &",\n{fieldInd}nfile_id: {h5f.file_id},\n"
+    result.add &"{fieldInd}err: {h5f.err},\n"
+    result.add &"{fieldInd}status: {h5f.status}"
   if h5f.datasets.len > 0:
-    result.add fieldInd & "datasets: {"
+    result.add &",\n{fieldInd}datasets: " & "{"
   for name, dset in h5f.datasets:
-    result.add fieldInd & name & ": " & dset.pretty(indent = indent + 4)
+    result.add &"{fieldInd}{name}: " & dset.pretty(indent = indent + 4)
   if h5f.datasets.len > 0:
-    result.add fieldInd & "}"
+    result.add &"{fieldInd}" & "}"
   if h5f.groups.len > 0:
-    result.add fieldInd & "groups: {"
+    result.add &",\n{fieldInd}groups: " & "{"
   for name, subGrp in h5f.groups:
-    result.add fieldInd & name & ": " & subGrp.pretty(indent = indent + 4)
+    result.add &"{fieldInd}{name}: " & subGrp.pretty(indent = indent + 4)
   if h5f.groups.len > 0:
     result.add fieldInd & "}"
-  result.add fieldInd & &"attrs: {h5f.attrs}"
+  result.add &",\n{fieldInd}attrs: {h5f.attrs}"
   result.add repeat(' ', indent) & "\n}"
 
 proc `$`*(grp: H5FileObj): string =


### PR DESCRIPTION
The implementation of `copy_attributes` so far assumed that the `attr_tab` was already filled with opened attributes.

However, when just opening a file in a session without having created the attributes the copy operation won't do anything. So instead we now read all attributes in the proc, copy each and then close each attribute again.

Also contains some fixes for string conversions.