### PR TITLE
remove dependency on typetraits, typeinfo, add custom enum

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,0 +1,4 @@
+* v0.3.8
+
+- remove dependency of =typetraits= and =typeinfo= modules by
+  introducing custom =DtypeKind enum=

--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -5,7 +5,6 @@ The attribute types are defined in the datatypes.nim file.
 ]#
 
 import typeinfo
-import typetraits
 import tables
 import strutils, sequtils
 
@@ -110,7 +109,7 @@ proc setAttrAnyKind(attr: H5Attr) =
   ## proc which sets the AnyKind fields of a H5Attr
   let npoints = H5Sget_simple_extent_npoints(attr.attr_dspace_id)
   if npoints > 1:
-    attr.dtypeAnyKind = akSequence
+    attr.dtypeAnyKind = dkSequence
     # set the base type based on what's contained in the sequence
     attr.dtypeBaseKind = h5ToNimType(attr.dtype_c)
   else:
@@ -443,79 +442,79 @@ template withAttr*(h5attr: H5Attributes, name: string, actions: untyped) =
   # TODO: NOTE this is a very ugly solution, when we could just use H5Ocopy in the calling
   # proc....
   case h5attr.attr_tab[name].dtypeAnyKind
-  of akBool:
+  of dkBool:
     let attr {.inject.} = h5attr[name, bool]
     actions
-  of akChar:
+  of dkChar:
     let attr {.inject.} = h5attr[name, char]
     actions
-  of akString:
+  of dkString:
     let attr {.inject.} = h5attr[name, string]
     actions
-  of akFloat32:
+  of dkFloat32:
     let attr {.inject.} = h5attr[name, float32]
     actions
-  of akFloat64:
+  of dkFloat64:
     let attr {.inject.} = h5attr[name, float64]
     actions
-  of akInt8:
+  of dkInt8:
     let attr {.inject.} = h5attr[name, int8]
     actions
-  of akInt16:
+  of dkInt16:
     let attr {.inject.} = h5attr[name, int16]
     actions
-  of akInt32:
+  of dkInt32:
     let attr {.inject.} = h5attr[name, int32]
     actions
-  of akInt64:
+  of dkInt64:
     let attr {.inject.} = h5attr[name, int64]
     actions
-  of akUint8:
+  of dkUint8:
     let attr {.inject.} = h5attr[name, uint8]
     actions
-  of akUint16:
+  of dkUint16:
     let attr {.inject.} = h5attr[name, uint16]
     actions
-  of akUint32:
+  of dkUint32:
     let attr {.inject.} = h5attr[name, uint32]
     actions
-  of akUint64:
+  of dkUint64:
     let attr {.inject.} = h5attr[name, uint64]
     actions
-  of akSequence:
+  of dkSequence:
     # need to perform same game again...
     case h5attr.attr_tab[name].dtypeBaseKind
-    of akString:
+    of dkString:
       let attr {.inject.} = h5attr[name, seq[string]]
       actions
-    of akFloat32:
+    of dkFloat32:
       let attr {.inject.} = h5attr[name, seq[float32]]
       actions
-    of akFloat64:
+    of dkFloat64:
       let attr {.inject.} = h5attr[name, seq[float64]]
       actions
-    of akInt8:
+    of dkInt8:
       let attr {.inject.} = h5attr[name, seq[int8]]
       actions
-    of akInt16:
+    of dkInt16:
       let attr {.inject.} = h5attr[name, seq[int16]]
       actions
-    of akInt32:
+    of dkInt32:
       let attr {.inject.} = h5attr[name, seq[int32]]
       actions
-    of akInt64:
+    of dkInt64:
       let attr {.inject.} = h5attr[name, seq[int64]]
       actions
-    of akUint8:
+    of dkUint8:
       let attr {.inject.} = h5attr[name, seq[uint8]]
       actions
-    of akUint16:
+    of dkUint16:
       let attr {.inject.} = h5attr[name, seq[uint16]]
       actions
-    of akUint32:
+    of dkUint32:
       let attr {.inject.} = h5attr[name, seq[uint32]]
       actions
-    of akUint64:
+    of dkUint64:
       let attr {.inject.} = h5attr[name, seq[uint64]]
       actions
     else:

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -246,9 +246,6 @@ proc getTypeNoSize(x: DtypeKind): DtypeKind =
     result = dkFloat
   of dkUint .. dkUint64:
     result = dkUint
-  else:
-    # for other cases (which ones?!) return dkNone
-    result = dkNone
 
 macro name*(t: typed): untyped =
   ## returns name of given data type

--- a/tests/tdset.nim
+++ b/tests/tdset.nim
@@ -2,7 +2,6 @@ import nimhdf5
 import sequtils
 import os
 import ospaths
-import typeinfo
 
 const
   File = "tests/dset.h5"
@@ -27,13 +26,14 @@ proc assert_fields(h5f: var H5FileObj, dset: var H5DataSet, parent = DsetName) =
   assert(dset.dtype == "float64")
 
   # currently if we hand a float64 for a datatype, we end up with
-  # akFloat after creation, but when reading it back we get a
-  # akFloat64. The first is due to Nim defining float64
+  # dkFloat after creation, but when reading it back we get a
+  # dkFloat64. The first is due to Nim defining float64
   # 1. as the default float type on a 64 bit machine
   # 2. in case of float64 actually even more nuanced, in the sense
   #    that Nim defines float as an alias for float64
-  let anyKindCheck = if dset.dtypeAnyKind == akFloat or dset.dtypeAnyKind == akFloat64: true else: false
-  assert(anyKindCheck)#dset.dtypeAnyKind == akFloat)
+  echo dset.dtypeAnyKind
+  let anyKindCheck = if dset.dtypeAnyKind == dkFloat or dset.dtypeAnyKind == dkFloat64: true else: false
+  assert(anyKindCheck)#dset.dtypeAnyKind == dkFloat)
 
   assert(dset.parent == parentDir(parent))
 

--- a/tests/tint64_dset.nim
+++ b/tests/tint64_dset.nim
@@ -2,7 +2,6 @@ import nimhdf5
 import sequtils
 import os
 import ospaths
-import typeinfo
 
 # simple test case used to test the usage of int64 as a type used for
 # `create_dataset`, which currently clashes with the definition of `hid_t`
@@ -25,8 +24,8 @@ when isMainModule:
     dset = h5f.create_dset()
   # perform 1st checks on still open file
   # close and reopen
-  assert dset.dtypeAnyKind == akInt64
-    
+  assert dset.dtypeAnyKind == dkInt64
+
   var err = h5f.close()
   assert(err >= 0)
   var
@@ -34,8 +33,8 @@ when isMainModule:
   # get same dset from before
   dset = h5f_read[DsetName.dset_str]
   # check if assertions still hold true (did we read correctly?)
-  assert dset.dtypeAnyKind == akInt64
-  
+  assert dset.dtypeAnyKind == dkInt64
+
   err = h5f_read.close()
   assert(err >= 0)
 

--- a/tests/treshape.nim
+++ b/tests/treshape.nim
@@ -5,12 +5,11 @@ import ospaths
 import typeinfo
 import strformat
 import algorithm
-import typetraits
 
 const
   File = "tests/treshape.h5"
   Dset2D = "/group1/reshape2D"
-  Dset3D = "/group1/reshape3D"  
+  Dset3D = "/group1/reshape3D"
 
 var d2d = @[ @[1, 1, 1],
              @[1, 1, 1],
@@ -23,7 +22,7 @@ var d3d = @[ @[ @[1, 2, 3, 4, 5],
 proc create_dset(h5f: var H5FileObj): (H5DataSet, H5DataSet) =
   var
     d1 = h5f.create_dataset(Dset2D, (3, 3), int)
-    d2 = h5f.create_dataset(Dset3D, (2, 2, 5), int)  
+    d2 = h5f.create_dataset(Dset3D, (2, 2, 5), int)
   d1[d1.all] = d2d
   d2[d2.all] = d3d
   result = (d1, d2)
@@ -52,7 +51,7 @@ proc assert_data(dset: var H5DataSet, shape: seq[int]) =
   else:
     # for the 3D case
     let data_reshaped = data.reshape3D(dset.shape)
-    let data_reshaped_alt = data.reshape([2, 2, 5])    
+    let data_reshaped_alt = data.reshape([2, 2, 5])
     assert data_reshaped.shape == d3d.shape
     assert data_reshaped_alt.shape == d3d.shape
     # in this case for convenience compare the flattened arrays
@@ -79,13 +78,13 @@ when isMainModule:
     h5f_read = H5File(File, "r")
   # get same dset from before
   dset2d = h5f_read[Dset2D.dset_str]
-  dset3d = h5f_read[Dset3D.dset_str]  
+  dset3d = h5f_read[Dset3D.dset_str]
   # check if assertions still hold true (did we read correctly?)
   echo "Asserting fields of read data"
   # now read actual data and compare with what we wrote to file
   assert_data(dset2d, @[3, 3])
-  assert_data(dset3d, @[2, 2, 5])  
-  
+  assert_data(dset3d, @[2, 2, 5])
+
   err = h5f_read.close()
   assert(err >= 0)
 

--- a/tests/tresize.nim
+++ b/tests/tresize.nim
@@ -2,7 +2,6 @@ import nimhdf5
 import sequtils
 import os
 import ospaths
-import typeinfo
 
 const
   File = "tests/dset.h5"
@@ -28,12 +27,12 @@ proc assert_fields(h5f: var H5FileObj, dset: var H5DataSet, resized: bool) =
   assert(dtypeCheck)
 
   # currently if we hand a float64 for a datatype, we end up with
-  # akFloat after creation, but when reading it back we get a
-  # akFloat64. The first is due to Nim defining float64
+  # dkFloat after creation, but when reading it back we get a
+  # dkFloat64. The first is due to Nim defining float64
   # 1. as the default float type on a 64 bit machine
   # 2. in case of float64 actually even more nuanced, in the sense
   #    that Nim defines float as an alias for float64
-  let anyKindCheck = if dset.dtypeAnyKind == akInt or dset.dtypeAnyKind == akInt64: true else: false
+  let anyKindCheck = if dset.dtypeAnyKind == dkInt or dset.dtypeAnyKind == dkInt64: true else: false
   assert(anyKindCheck)
 
   assert(dset.parent == parentDir(DsetName))

--- a/tests/tvlen_array.nim
+++ b/tests/tvlen_array.nim
@@ -23,12 +23,12 @@ proc doAssert_fields(h5f: var H5FileObj, dset: var H5DataSet) =
   doAssert(dset.dtype == "vlen")
 
   # currently if we hand a float64 for a datatype, we end up with
-  # akFloat after creation, but when reading it back we get a
-  # akFloat64. The first is due to Nim defining float64
+  # dkFloat after creation, but when reading it back we get a
+  # dkFloat64. The first is due to Nim defining float64
   # 1. as the default float type on a 64 bit machine
   # 2. in case of float64 actually even more nuanced, in the sense
   #    that Nim defines float as an alias for float64
-  let baseKindCheck = if dset.dtypeBaseKind == akFloat or dset.dtypeBaseKind == akFloat64: true else: false
+  let baseKindCheck = if dset.dtypeBaseKind == dkFloat or dset.dtypeBaseKind == dkFloat64: true else: false
   doAssert(baseKindCheck)
 
   doAssert(dset.parent == parentDir(VlenName))


### PR DESCRIPTION
Due to the recent devel changes, which forbid `for x in MyEnum` if `MyEnum` is an enum with holes, our code broke, since we used `typeinfo.AnyKind` as a convenient enum to store type information.

Related upstream issue: https://github.com/nim-lang/Nim/issues/14030

Instead of using the `AnyKind` enum, which is a holed enum, define our
own. Also don't need to workaround using a tmp variable of a dtype and
then use `toAny.kind` to get the correct `AnyKind`. Just use custom
macro to get name of type (which can extract it from generic T) and
parse to new enum.

Good to avoid the dependency on those two modules anyways, especially to get rid of that weird `tmp.toAny.kind` workaround.