### PR TITLE
Fixes mapping of H5 types to Nim types, fixes #35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
   - export PATH=$HOME/.nimble/bin:$PATH
   - nimble refresh -y
   - choosenim $CHANNEL
+  - nim --version
 
 script:
   - nimble install -y

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -32,3 +32,4 @@ task test, "Runs all tests":
   # regression tests
   exec "nim c -r tests/tint64_dset.nim"
   exec "nim c -r tests/t17.nim"
+  exec "nim c -r tests/tIntegerTypes.nim"

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -7,7 +7,8 @@ The H5DataSet type is defined in the datatypes.nim file.
 import options
 import tables
 import strutils
-export nimIdentNormalize
+when (NimMajor, NimMinor, NimPatch) > (1, 2, 0):
+  export nimIdentNormalize
 import sequtils
 import seqmath
 import macros

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -7,6 +7,7 @@ The H5DataSet type is defined in the datatypes.nim file.
 import options
 import tables
 import strutils
+export nimIdentNormalize
 import sequtils
 import seqmath
 import macros

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -4,10 +4,17 @@ This file contains all procedures related to datasets.
 The H5DataSet type is defined in the datatypes.nim file.
 ]#
 
+## TODO: this is only a workaround, because `choosenim` devel on travis
+## has a nim version from `19/04/20`, which was before the `parseEnum`
+## PR was merged
+template tryExport(body: untyped): untyped =
+  when compiles(body):
+    discard
+
 import options
 import tables
 import strutils
-when (NimMajor, NimMinor, NimPatch) > (1, 2, 0):
+tryExport:
   export nimIdentNormalize
 import sequtils
 import seqmath

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -292,28 +292,42 @@ proc h5ToNimType*(dtype_id: hid_t): DtypeKind =
   withDebug:
     echo "dtype is ", dtype_id
     echo "native is ", H5Tget_native_type(dtype_id, H5T_DIR_ASCEND)
-  # TODO: make sure the types are correctly identified!
-  # MAKING PROBLEMS ALREADY! int64 is read back as a NATIVE_LONG, which thus needs to be
-  # converted to int64
-
   if H5Tequal(H5T_NATIVE_DOUBLE, dtype_id) == 1:
     result = dkFloat64
   elif H5Tequal(H5T_NATIVE_FLOAT, dtype_id) == 1:
     result = dkFloat32
-  elif H5Tequal(H5T_NATIVE_SHORT, dtype_id) == 1:
+  elif H5Tequal(H5T_NATIVE_LONG, dtype_id) == 1:
+    # maps to `long`
+    case sizeof(clong)
+    of 4: result = dkInt32
+    of 8: result = dkInt64
+    else: doAssert false, "`long` of size other than 4, 8 bytes?"
+  elif H5Tequal(H5T_NATIVE_INT, dtype_id) == 1:
+    # maps to `int`
+    doAssert sizeof(cint) == 4
     result = dkInt32
-  elif H5Tequal(H5T_NATIVE_LONG, dtype_id) == 1 or H5Tequal(H5T_NATIVE_INT, dtype_id) == 1 or H5Tequal(H5T_NATIVE_LLONG, dtype_id) == 1:
+  elif H5Tequal(H5T_NATIVE_LLONG, dtype_id) == 1:
+    # maps to `long long`
+    doAssert sizeof(clonglong) == 8
     result = dkInt64
-  elif H5Tequal(H5T_NATIVE_UINT, dtype_id) == 1 or H5Tequal(H5T_NATIVE_ULONG, dtype_id) == 1:
+  elif H5Tequal(H5T_NATIVE_UINT, dtype_id) == 1:
+    # maps to `unsigned`
+    doAssert sizeof(cuint) == 4
     result = dkUint32
+  elif H5Tequal(H5T_NATIVE_ULONG, dtype_id) == 1:
+    case sizeof(culong)
+    of 4: result = dkUint32
+    of 8: result = dkUint64
+    else: doAssert false, "`unsigned long` of size other than 4, 8 bytes?"
   elif H5Tequal(H5T_NATIVE_ULLONG, dtype_id) == 1:
+    doAssert sizeof(culonglong) == 8
     result = dkUint64
   elif H5Tequal(H5T_NATIVE_SHORT, dtype_id) == 1:
     result = dkInt16
   elif H5Tequal(H5T_NATIVE_USHORT, dtype_id) == 1:
     result = dkUint16
   elif H5Tequal(H5T_NATIVE_CHAR, dtype_id) == 1:
-    result = dkChar
+    result = dkInt8
   elif H5Tequal(H5T_NATIVE_UCHAR, dtype_id) == 1:
     result = dkUint8
   elif H5Tget_class(dtype_id) == H5T_STRING:

--- a/tests/tIntegerTypes.nim
+++ b/tests/tIntegerTypes.nim
@@ -1,0 +1,63 @@
+import nimhdf5
+import sequtils
+import os
+import ospaths
+
+# simple test which checks mapping, writing and reading of
+# different integer types
+
+const
+  File = "tests/tIntegerTypes.h5"
+  di64 = @[1'i64, 2, 3, 4]
+  di32 = @[1'i32, 2, 3, 4]
+  di16 = @[1'i16, 2, 3, 4]
+  di8 = @[1'i8, 2, 3, 4]
+  du64 = @[1'u64, 2, 3, 4]
+  du32 = @[1'u32, 2, 3, 4]
+  du16 = @[1'u16, 2, 3, 4]
+  du8 = @[1'u8, 2, 3, 4]
+
+proc write[T; U](h5f: var H5FileObj, data: T, dtype: typedesc[U]): H5DataSet =
+  echo "/dset" & $dtype
+  result = h5f.create_dataset("/dset" & $dtype, 4, dtype)
+  result[result.all] = data
+
+proc read[T](h5f: var H5FileObj, dtype: typedesc[T]): seq[T] =
+  let dset = "/dset" & $dtype
+  echo "READING ", dset
+  let dd = h5f[dset.dset_str]
+  result = dd[dtype]
+
+when isMainModule:
+  # open file, create dataset
+  var
+    h5f = H5File(File, "rw")
+
+  # write all datasets
+  doAssert h5f.write(di64, int64).dtypeAnyKind == dkInt64
+  doAssert h5f.write(di32, int32).dtypeAnyKind == dkInt32
+  doAssert h5f.write(di16, int16).dtypeAnyKind == dkInt16
+  doAssert h5f.write(di8, int8).dtypeAnyKind == dkInt8
+  doAssert h5f.write(du64, uint64).dtypeAnyKind == dkUInt64
+  doAssert h5f.write(du32, uint32).dtypeAnyKind == dkUInt32
+  doAssert h5f.write(du16, uint16).dtypeAnyKind == dkUInt16
+  doAssert h5f.write(du8, uint8).dtypeAnyKind == dkUInt8
+
+  var err = h5f.close()
+  assert(err >= 0)
+  h5f = H5File(File, "r")
+
+  doAssert h5f.read(int64) == di64
+  doAssert h5f.read(int32) == di32
+  doAssert h5f.read(int16) == di16
+  doAssert h5f.read(int8) == di8
+  doAssert h5f.read(uint64) == du64
+  doAssert h5f.read(uint32) == du32
+  doAssert h5f.read(uint16) == du16
+  doAssert h5f.read(uint8) == du8
+
+  err = h5f.close()
+  assert(err >= 0)
+
+  # clean up after ourselves
+  #removeFile(File)


### PR DESCRIPTION
Some of the mappings from H5 types to Nim types were wrong.

We now check the size of types on the target using `sizeof` where possibly ambiguous.

Fixes #35.