### PR TITLE
add compound datatypes, seq[string] attributes, fix csize ⇒ csize_t

### DIFF
--- a/README.org
+++ b/README.org
@@ -188,6 +188,12 @@ know.
   - writing / reading static sized N-D arrays of any type
   - writing / reading variable length data
   - chunked storage
+- data types:
+  - any basic nim type, that is:
+    - SomeNumber (all ints and floats)
+    - string (not for datasets atm)
+  - compound datatypes of objects / tuples, where the fields have to
+    be of the above mentioned basic types.
 - hyperslabs
   - writing / reading hyperslabs using H5 notation
 - compression / filters
@@ -217,8 +223,3 @@ know.
   - datasets
   - attributes
 
-** Major missing HDF5 features
-Most major HDF5 features are now supported (although they may not be
-perfectly stable yet, due to limited testing). The major exception
-is the following:
-- support for compound data types

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,17 @@
+* v0.3.11
+- change usage of =csize= to =csize_t= in full wrapper / library. For
+  most use cases this did not have any effect (=csize= was an int,
+  instead of unsigned). But for =H5T_VARIABLE = csize.high= this
+  caused problems, because the value was not the one expected
+  (=csize_t.high=)
+- add support for =seq[string]= attributes
+- reorder =datasets.nim= and clean up =[]= logic
+- add =[]= accessor from a =H5Group=
+- add =isVlen= helper to check if dataset is variable length
+- make =special_type= usage optional when reading datasets
+* v0.3.10
+- change =dtypeAnyKind= definition when creating dataset
+- improve iteration over subgroups / datasets
 * v0.3.9
 - fix mapping of H5 types to Nim types, see PR #36.
 

--- a/changelog.org
+++ b/changelog.org
@@ -4,11 +4,23 @@
   instead of unsigned). But for =H5T_VARIABLE = csize.high= this
   caused problems, because the value was not the one expected
   (=csize_t.high=)
+- add support for compound datatypes. Creating a dataset / writing and
+  reading data works for any objects `T` which have fields that can be
+  stored in HDF5 files currently. 
+  Objects and tuples are treated the same!
 - add support for =seq[string]= attributes
 - reorder =datasets.nim= and clean up =[]= logic
 - add =[]= accessor from a =H5Group=
 - add =isVlen= helper to check if dataset is variable length
 - make =special_type= usage optional when reading datasets
+- fix branching in =nimToH5type= to be fully compile time
+- add =H5File= to replace =H5FileObj= (latter is kept as deprecated
+  typedef)
+- variable lenght data is created automatically if user gives =seq[T]=
+  type in =create_dataset=
+- =read= can automatically read variable length data if =seq[T]=
+  datatype is given
+- add tests for compound data and =seq[string]= attributes
 * v0.3.10
 - change =dtypeAnyKind= definition when creating dataset
 - improve iteration over subgroups / datasets

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -29,6 +29,7 @@ task test, "Runs all tests":
   exec "nim c -r tests/tconvert.nim"
   exec "nim c -r tests/tdelete.nim"
   exec "nim c -r tests/tresize_by_add.nim"
+  exec "nim c -r tests/tStringAttributes.nim"
   # regression tests
   exec "nim c -r tests/tint64_dset.nim"
   exec "nim c -r tests/t17.nim"

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.10"
+version       = "0.3.11"
 author        = "Sebastian Schmidt"
 description   = "Bindings for the HDF5 data format C library"
 license       = "MIT"
@@ -30,6 +30,7 @@ task test, "Runs all tests":
   exec "nim c -r tests/tdelete.nim"
   exec "nim c -r tests/tresize_by_add.nim"
   exec "nim c -r tests/tStringAttributes.nim"
+  exec "nim c -r tests/tCompound.nim"
   # regression tests
   exec "nim c -r tests/tint64_dset.nim"
   exec "nim c -r tests/t17.nim"

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -11,7 +11,7 @@ skipExt       = @["nim~"]
 # Dependencies
 
 requires "nim >= 1.0.0"
-requires "https://github.com/vindaar/seqmath >= 0.1.5"
+requires "https://github.com/vindaar/seqmath >= 0.1.12"
 
 task test, "Runs all tests":
   exec "nim c -r tests/tbasic.nim"

--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -75,11 +75,11 @@ proc getAttrName*[T: SomeInteger](attr_id: hid_t, buf_space: T = 200): string =
     debugEcho "Call to getAttrName! with size $#" % $buf_space
   var name = newString(buf_space)
   # read the name
-  let length = attr_id.H5Aget_name(len(name).csize, name)
+  let length = attr_id.H5Aget_name(len(name).csize_t, name)
   # H5Aget_name returns the length of the name. In case the name
   # is longer than the given buffer, we call this function again with
   # a buffer with the correct length
-  if length <= name.len.csize:
+  if length <= name.len.csize_t:
     result = name.strip
     # now set the length of the resulting string to the size
     # it actually occupies

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -822,7 +822,7 @@ proc select_elements[T](dset: H5DataSet, coord: seq[T]): hid_t {.inline, discard
   result = dset.dataspace_id
   let res = H5Sselect_elements(result,
                                H5S_SELECT_SET,
-                               csize(coord.len),
+                               csize_t(coord.len),
                                addr(flat_coord[0]))
   if res < 0:
     raise newException(HDF5LibraryError, "Call to HDF5 library failed in `select_elements` " &

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -369,7 +369,8 @@ proc create_dataset*[T: (tuple | int | seq)](
   ##           `int`: for 1D datasets
   ##           `tuple` / `seq`: for N dim. datasets
   ##    dtype = typedesc = a Nim typedesc (e.g. int, float, etc.) for that
-  ##            dataset. vlen not yet supported
+  ##            dataset. If a sequence type is given it will create a variable length
+  ##            dataset.
   ##    chunksize: seq[int] = a sequence containing the chunksize, the dataset should be
   ##            should be chunked in (if any). Empty seq: no chunking (but no resizing either!)
   ##    maxshape: seq[int] = a sequence containing the maxmimum sizes for each

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -372,7 +372,7 @@ proc nimToH5type*(dtype: typedesc): hid_t =
   else:
     if dtype is int:
       result = H5T_NATIVE_INT
-  if dtype is int64:
+  when dtype is int64:
     result = H5T_NATIVE_LONG
   elif dtype is uint8:
     # for 8 bit int we take the STD LE one, since there is no

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -417,14 +417,13 @@ proc getDtypeString*(dset_id: hid_t): string =
   let t = H5Dget_type(dset_id)
   result = anyTypeToString(h5ToNimType(t))
 
-template special_type*(dtype: typedesc): untyped =
+proc special_type*(dtype: typedesc): hid_t =
   ## calls the H5Tvlen_create() to create a special datatype
   ## for variable length data
   when dtype isnot string:
-    H5Tvlen_create(nimToH5type(dtype))
+    result = H5Tvlen_create(nimToH5type(dtype))
   else:
-    echo "Currently not implemented to create variable string datatype"
-
+    doAssert false, "Currently not implemented to create variable string datatype"
 
 proc parseH5rw_type*(rw_type: string, exists: bool): cuint =
   ## this proc simply acts as a parser for the read/write

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -469,15 +469,15 @@ template toH5vlen*[T](data: var seq[T]): untyped =
   when T is seq:
     mapIt(toSeq(0..data.high)) do:
       if data[it].len > 0:
-        hvl_t(`len`: csize(data[it].len), p: addr(data[it][0]))
+        hvl_t(`len`: csize_t(data[it].len), p: addr(data[it][0]))
       else:
-        hvl_t(`len`: csize(0), p: nil)
+        hvl_t(`len`: csize_t(0), p: nil)
   else:
     # this doesn't make sense ?!...
     static:
       warning("T is " & T.name)
       warning("Cannot be converted to VLEN data!")
-    #mapIt(toSeq(0 .. data.high), hvl_t(`len`: csize(data[it]), p: addr(data[it][0])))
+    #mapIt(toSeq(0 .. data.high), hvl_t(`len`: csize_t(data[it]), p: addr(data[it][0])))
 
 proc vlenToSeq*[T](data: seq[hvl_t]): seq[seq[T]] =
   # converting the raw data from the C library to a Nim sequence is sort of ugly, but

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -165,7 +165,9 @@ type
     # here we store H5P_GROUP_CREATE property list
     gcpl_id*: hid_t
 
-  H5FileObj* = ref object
+  H5FileObj* {.deprecated: "Use `H5File` instead. This is a leftover naming scheme " &
+    "from when the H5 objects were not ref objects. This is an alias for H5File.".} = H5File
+  H5File* = ref object
     name*: string
     # the file_id is the unique identifier of the opened file. Each
     # low level C call uses this file_id to idenfity the file to work

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -249,7 +249,9 @@ proc close*(id: hid_t, kind: ObjectKind): herr_t =
 
 proc close*(h5f: H5FileObj): herr_t =
   ## this procedure closes all known datasets, dataspaces, groups and the HDF5 file
-  ## itself to clean up
+  ## itself to clean up.
+  ## The return value will be non negative if the closing was successful and negative
+  ## otherwise.
   ## inputs:
   ##    h5f: H5FileObj = file object which to close
   ## outputs:

--- a/src/nimhdf5/filters.nim
+++ b/src/nimhdf5/filters.nim
@@ -83,7 +83,7 @@ proc setFilters*(dset: H5DataSet, filter: H5Filter) =
       filterVals[6] = filter.compressor.cuint
       # set the filter
       status = H5Pset_filter(dset.dcpl_id, FILTER_BLOSC, H5Z_FLAG_OPTIONAL,
-                             filterVals.len.csize, addr filterVals[0])
+                             filterVals.len.csize_t, addr filterVals[0])
     else:
       raise newException(NotImplementedError, "Blosc support not available, due " &
         "to missing `nblosc` library!")

--- a/src/nimhdf5/groups.nim
+++ b/src/nimhdf5/groups.nim
@@ -9,8 +9,6 @@ import datatypes
 import attributes
 import h5util
 import util
-#import datasets
-#from h5util import `$`
 
 # get visit_file from files.nim for dataset iterator
 from files import visit_file

--- a/src/nimhdf5/hl/H5DOpublic.nim
+++ b/src/nimhdf5/hl/H5DOpublic.nim
@@ -23,18 +23,18 @@ when not declared(libname_hl):
   else:
     const
       libname_hl* = "libhdf5_hl.so"
-    
+
 
 ## -------------------------------------------------------------------------
-## 
+##
 ##  "Optimized dataset" routines.
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5DOwrite_chunk*(dset_id: hid_t; dxpl_id: hid_t; filters: uint32_t;
-                     offset: ptr hsize_t; data_size: csize; buf: pointer): herr_t {.
+                     offset: ptr hsize_t; data_size: csize_t; buf: pointer): herr_t {.
     cdecl, importc: "H5DOwrite_chunk", dynlib: libname_hl.}
-proc H5DOappend*(dset_id: hid_t; dxpl_id: hid_t; axis: cuint; extension: csize;
+proc H5DOappend*(dset_id: hid_t; dxpl_id: hid_t; axis: cuint; extension: csize_t;
                 memtype: hid_t; buf: pointer): herr_t {.cdecl, importc: "H5DOappend",
     dynlib: libname_hl.}

--- a/src/nimhdf5/hl/H5DSpublic.nim
+++ b/src/nimhdf5/hl/H5DSpublic.nim
@@ -43,9 +43,9 @@ proc H5DSget_num_scales*(did: hid_t; dim: cuint): cint {.cdecl,
     importc: "H5DSget_num_scales", dynlib: libname_hl.}
 proc H5DSset_label*(did: hid_t; idx: cuint; label: cstring): herr_t {.cdecl,
     importc: "H5DSset_label", dynlib: libname_hl.}
-proc H5DSget_label*(did: hid_t; idx: cuint; label: cstring; size: csize): ssize_t {.cdecl,
+proc H5DSget_label*(did: hid_t; idx: cuint; label: cstring; size: csize_t): ssize_t {.cdecl,
     importc: "H5DSget_label", dynlib: libname_hl.}
-proc H5DSget_scale_name*(did: hid_t; name: cstring; size: csize): ssize_t {.cdecl,
+proc H5DSget_scale_name*(did: hid_t; name: cstring; size: csize_t): ssize_t {.cdecl,
     importc: "H5DSget_scale_name", dynlib: libname_hl.}
 proc H5DSis_scale*(did: hid_t): htri_t {.cdecl, importc: "H5DSis_scale",
                                      dynlib: libname_hl.}

--- a/src/nimhdf5/hl/H5LDpublic.nim
+++ b/src/nimhdf5/hl/H5LDpublic.nim
@@ -25,7 +25,7 @@ when not declared(libname_hl):
 
 proc H5LDget_dset_dims*(did: hid_t; cur_dims: ptr hsize_t): herr_t {.cdecl,
     importc: "H5LDget_dset_dims", dynlib: libname_hl.}
-proc H5LDget_dset_type_size*(did: hid_t; fields: cstring): csize {.cdecl,
+proc H5LDget_dset_type_size*(did: hid_t; fields: cstring): csize_t {.cdecl,
     importc: "H5LDget_dset_type_size", dynlib: libname_hl.}
 proc H5LDget_dset_elmts*(did: hid_t; prev_dims: ptr hsize_t; cur_dims: ptr hsize_t;
                         fields: cstring; buf: pointer): herr_t {.cdecl,

--- a/src/nimhdf5/hl/H5LTpublic.nim
+++ b/src/nimhdf5/hl/H5LTpublic.nim
@@ -50,11 +50,11 @@ type
 
 
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Make dataset functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTmake_dataset*(loc_id: hid_t; dset_name: cstring; rank: cint;
                       dims: ptr hsize_t; type_id: hid_t; buffer: pointer): herr_t {.
@@ -80,11 +80,11 @@ proc H5LTmake_dataset_double*(loc_id: hid_t; dset_name: cstring; rank: cint;
 proc H5LTmake_dataset_string*(loc_id: hid_t; dset_name: cstring; buf: cstring): herr_t {.
     cdecl, importc: "H5LTmake_dataset_string", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Read dataset functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTread_dataset*(loc_id: hid_t; dset_name: cstring; type_id: hid_t;
                       buffer: pointer): herr_t {.cdecl, importc: "H5LTread_dataset",
@@ -104,69 +104,69 @@ proc H5LTread_dataset_double*(loc_id: hid_t; dset_name: cstring; buffer: ptr cdo
 proc H5LTread_dataset_string*(loc_id: hid_t; dset_name: cstring; buf: cstring): herr_t {.
     cdecl, importc: "H5LTread_dataset_string", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Query dataset functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTget_dataset_ndims*(loc_id: hid_t; dset_name: cstring; rank: ptr cint): herr_t {.
     cdecl, importc: "H5LTget_dataset_ndims", dynlib: libname_hl.}
 proc H5LTget_dataset_info*(loc_id: hid_t; dset_name: cstring; dims: ptr hsize_t;
-                          type_class: ptr H5T_class_t; type_size: ptr csize): herr_t {.
+                          type_class: ptr H5T_class_t; type_size: ptr csize_t): herr_t {.
     cdecl, importc: "H5LTget_dataset_info", dynlib: libname_hl.}
 proc H5LTfind_dataset*(loc_id: hid_t; name: cstring): herr_t {.cdecl,
     importc: "H5LTfind_dataset", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Set attribute functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTset_attribute_string*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
                               attr_data: cstring): herr_t {.cdecl,
     importc: "H5LTset_attribute_string", dynlib: libname_hl.}
 proc H5LTset_attribute_char*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                            buffer: cstring; size: csize): herr_t {.cdecl,
+                            buffer: cstring; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_char", dynlib: libname_hl.}
 proc H5LTset_attribute_uchar*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                             buffer: ptr cuchar; size: csize): herr_t {.cdecl,
+                             buffer: ptr cuchar; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_uchar", dynlib: libname_hl.}
 proc H5LTset_attribute_short*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                             buffer: ptr cshort; size: csize): herr_t {.cdecl,
+                             buffer: ptr cshort; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_short", dynlib: libname_hl.}
 proc H5LTset_attribute_ushort*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                              buffer: ptr cushort; size: csize): herr_t {.cdecl,
+                              buffer: ptr cushort; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_ushort", dynlib: libname_hl.}
 proc H5LTset_attribute_int*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                           buffer: ptr cint; size: csize): herr_t {.cdecl,
+                           buffer: ptr cint; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_int", dynlib: libname_hl.}
 proc H5LTset_attribute_uint*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                            buffer: ptr cuint; size: csize): herr_t {.cdecl,
+                            buffer: ptr cuint; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_uint", dynlib: libname_hl.}
 proc H5LTset_attribute_long*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                            buffer: ptr clong; size: csize): herr_t {.cdecl,
+                            buffer: ptr clong; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_long", dynlib: libname_hl.}
 proc H5LTset_attribute_long_long*(loc_id: hid_t; obj_name: cstring;
                                  attr_name: cstring; buffer: ptr clonglong;
-                                 size: csize): herr_t {.cdecl,
+                                 size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_long_long", dynlib: libname_hl.}
 proc H5LTset_attribute_ulong*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                             buffer: ptr culong; size: csize): herr_t {.cdecl,
+                             buffer: ptr culong; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_ulong", dynlib: libname_hl.}
 proc H5LTset_attribute_float*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                             buffer: ptr cfloat; size: csize): herr_t {.cdecl,
+                             buffer: ptr cfloat; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_float", dynlib: libname_hl.}
 proc H5LTset_attribute_double*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
-                              buffer: ptr cdouble; size: csize): herr_t {.cdecl,
+                              buffer: ptr cdouble; size: csize_t): herr_t {.cdecl,
     importc: "H5LTset_attribute_double", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Get attribute functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTget_attribute*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
                        mem_type_id: hid_t; data: pointer): herr_t {.cdecl,
@@ -208,48 +208,48 @@ proc H5LTget_attribute_double*(loc_id: hid_t; obj_name: cstring; attr_name: cstr
                               data: ptr cdouble): herr_t {.cdecl,
     importc: "H5LTget_attribute_double", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Query attribute functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTget_attribute_ndims*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
                              rank: ptr cint): herr_t {.cdecl,
     importc: "H5LTget_attribute_ndims", dynlib: libname_hl.}
 proc H5LTget_attribute_info*(loc_id: hid_t; obj_name: cstring; attr_name: cstring;
                             dims: ptr hsize_t; type_class: ptr H5T_class_t;
-                            type_size: ptr csize): herr_t {.cdecl,
+                            type_size: ptr csize_t): herr_t {.cdecl,
     importc: "H5LTget_attribute_info", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  General functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTtext_to_dtype*(text: cstring; lang_type: H5LT_lang_t): hid_t {.cdecl,
     importc: "H5LTtext_to_dtype", dynlib: libname_hl.}
 proc H5LTdtype_to_text*(dtype: hid_t; str: cstring; lang_type: H5LT_lang_t;
-                       len: ptr csize): herr_t {.cdecl, importc: "H5LTdtype_to_text",
+                       len: ptr csize_t): herr_t {.cdecl, importc: "H5LTdtype_to_text",
     dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Utility functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5LTfind_attribute*(loc_id: hid_t; name: cstring): herr_t {.cdecl,
     importc: "H5LTfind_attribute", dynlib: libname_hl.}
 proc H5LTpath_valid*(loc_id: hid_t; path: cstring; check_object_valid: hbool_t): htri_t {.
     cdecl, importc: "H5LTpath_valid", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  File image operations functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
-proc H5LTopen_file_image*(buf_ptr: pointer; buf_size: csize; flags: cuint): hid_t {.
+proc H5LTopen_file_image*(buf_ptr: pointer; buf_size: csize_t; flags: cuint): hid_t {.
     cdecl, importc: "H5LTopen_file_image", dynlib: libname_hl.}

--- a/src/nimhdf5/hl/H5PTpublic.nim
+++ b/src/nimhdf5/hl/H5PTpublic.nim
@@ -26,7 +26,7 @@ when not declared(libname_hl):
 ## -------------------------------------------------------------------------
 ##  Create/Open/Close functions
 ## -------------------------------------------------------------------------
-## 
+##
 ##  NOTE: H5PTcreate is replacing H5PTcreate_fl for better name due to the
 ##    removal of H5PTcreate_vl.  H5PTcreate_fl may be retired in 1.8.19.
 
@@ -44,23 +44,23 @@ proc H5PTcreate_fl*(loc_id: hid_t; dset_name: cstring; dtype_id: hid_t;
 ## -------------------------------------------------------------------------
 ##  Write functions
 ## -------------------------------------------------------------------------
-## 
+##
 
-proc H5PTappend*(table_id: hid_t; nrecords: csize; data: pointer): herr_t {.cdecl,
+proc H5PTappend*(table_id: hid_t; nrecords: csize_t; data: pointer): herr_t {.cdecl,
     importc: "H5PTappend", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
 ##  Read functions
 ## -------------------------------------------------------------------------
-## 
+##
 
-proc H5PTget_next*(table_id: hid_t; nrecords: csize; data: pointer): herr_t {.cdecl,
+proc H5PTget_next*(table_id: hid_t; nrecords: csize_t; data: pointer): herr_t {.cdecl,
     importc: "H5PTget_next", dynlib: libname_hl.}
-proc H5PTread_packets*(table_id: hid_t; start: hsize_t; nrecords: csize; data: pointer): herr_t {.
+proc H5PTread_packets*(table_id: hid_t; start: hsize_t; nrecords: csize_t; data: pointer): herr_t {.
     cdecl, importc: "H5PTread_packets", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
 ##  Inquiry functions
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5PTget_num_packets*(table_id: hid_t; nrecords: ptr hsize_t): herr_t {.cdecl,
     importc: "H5PTget_num_packets", dynlib: libname_hl.}
@@ -69,22 +69,22 @@ proc H5PTis_valid*(table_id: hid_t): herr_t {.cdecl, importc: "H5PTis_valid",
 proc H5PTis_varlen*(table_id: hid_t): herr_t {.cdecl, importc: "H5PTis_varlen",
     dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Accessor functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5PTget_dataset*(table_id: hid_t): hid_t {.cdecl, importc: "H5PTget_dataset",
     dynlib: libname_hl.}
 proc H5PTget_type*(table_id: hid_t): hid_t {.cdecl, importc: "H5PTget_type",
     dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Packet Table "current index" functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5PTcreate_index*(table_id: hid_t): herr_t {.cdecl, importc: "H5PTcreate_index",
     dynlib: libname_hl.}
@@ -93,11 +93,11 @@ proc H5PTset_index*(table_id: hid_t; pt_index: hsize_t): herr_t {.cdecl,
 proc H5PTget_index*(table_id: hid_t; pt_index: ptr hsize_t): herr_t {.cdecl,
     importc: "H5PTget_index", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Memory Management functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
-proc H5PTfree_vlen_buff*(table_id: hid_t; bufflen: csize; buff: pointer): herr_t {.
+proc H5PTfree_vlen_buff*(table_id: hid_t; bufflen: csize_t; buff: pointer): herr_t {.
     cdecl, importc: "H5PTfree_vlen_buff", dynlib: libname_hl.}

--- a/src/nimhdf5/hl/H5TBpublic.nim
+++ b/src/nimhdf5/hl/H5TBpublic.nim
@@ -24,92 +24,92 @@ when not declared(libname_hl):
       libname_hl* = "libhdf5_hl.so"
 
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Create functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5TBmake_table*(table_title: cstring; loc_id: hid_t; dset_name: cstring;
-                    nfields: hsize_t; nrecords: hsize_t; type_size: csize;
-                    field_names: ptr cstring; field_offset: ptr csize;
+                    nfields: hsize_t; nrecords: hsize_t; type_size: csize_t;
+                    field_names: ptr cstring; field_offset: ptr csize_t;
                     field_types: ptr hid_t; chunk_size: hsize_t; fill_data: pointer;
                     compress: cint; buf: pointer): herr_t {.cdecl,
     importc: "H5TBmake_table", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Write functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5TBappend_records*(loc_id: hid_t; dset_name: cstring; nrecords: hsize_t;
-                        type_size: csize; field_offset: ptr csize;
-                        dst_sizes: ptr csize; buf: pointer): herr_t {.cdecl,
+                        type_size: csize_t; field_offset: ptr csize_t;
+                        dst_sizes: ptr csize_t; buf: pointer): herr_t {.cdecl,
     importc: "H5TBappend_records", dynlib: libname_hl.}
 proc H5TBwrite_records*(loc_id: hid_t; dset_name: cstring; start: hsize_t;
-                       nrecords: hsize_t; type_size: csize; field_offset: ptr csize;
-                       dst_sizes: ptr csize; buf: pointer): herr_t {.cdecl,
+                       nrecords: hsize_t; type_size: csize_t; field_offset: ptr csize_t;
+                       dst_sizes: ptr csize_t; buf: pointer): herr_t {.cdecl,
     importc: "H5TBwrite_records", dynlib: libname_hl.}
 proc H5TBwrite_fields_name*(loc_id: hid_t; dset_name: cstring; field_names: cstring;
-                           start: hsize_t; nrecords: hsize_t; type_size: csize;
-                           field_offset: ptr csize; dst_sizes: ptr csize; buf: pointer): herr_t {.
+                           start: hsize_t; nrecords: hsize_t; type_size: csize_t;
+                           field_offset: ptr csize_t; dst_sizes: ptr csize_t; buf: pointer): herr_t {.
     cdecl, importc: "H5TBwrite_fields_name", dynlib: libname_hl.}
 proc H5TBwrite_fields_index*(loc_id: hid_t; dset_name: cstring; nfields: hsize_t;
                             field_index: ptr cint; start: hsize_t; nrecords: hsize_t;
-                            type_size: csize; field_offset: ptr csize;
-                            dst_sizes: ptr csize; buf: pointer): herr_t {.cdecl,
+                            type_size: csize_t; field_offset: ptr csize_t;
+                            dst_sizes: ptr csize_t; buf: pointer): herr_t {.cdecl,
     importc: "H5TBwrite_fields_index", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Read functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
-proc H5TBread_table*(loc_id: hid_t; dset_name: cstring; dst_size: csize;
-                    dst_offset: ptr csize; dst_sizes: ptr csize; dst_buf: pointer): herr_t {.
+proc H5TBread_table*(loc_id: hid_t; dset_name: cstring; dst_size: csize_t;
+                    dst_offset: ptr csize_t; dst_sizes: ptr csize_t; dst_buf: pointer): herr_t {.
     cdecl, importc: "H5TBread_table", dynlib: libname_hl.}
 proc H5TBread_fields_name*(loc_id: hid_t; dset_name: cstring; field_names: cstring;
-                          start: hsize_t; nrecords: hsize_t; type_size: csize;
-                          field_offset: ptr csize; dst_sizes: ptr csize; buf: pointer): herr_t {.
+                          start: hsize_t; nrecords: hsize_t; type_size: csize_t;
+                          field_offset: ptr csize_t; dst_sizes: ptr csize_t; buf: pointer): herr_t {.
     cdecl, importc: "H5TBread_fields_name", dynlib: libname_hl.}
 proc H5TBread_fields_index*(loc_id: hid_t; dset_name: cstring; nfields: hsize_t;
                            field_index: ptr cint; start: hsize_t; nrecords: hsize_t;
-                           type_size: csize; field_offset: ptr csize;
-                           dst_sizes: ptr csize; buf: pointer): herr_t {.cdecl,
+                           type_size: csize_t; field_offset: ptr csize_t;
+                           dst_sizes: ptr csize_t; buf: pointer): herr_t {.cdecl,
     importc: "H5TBread_fields_index", dynlib: libname_hl.}
 proc H5TBread_records*(loc_id: hid_t; dset_name: cstring; start: hsize_t;
-                      nrecords: hsize_t; type_size: csize; dst_offset: ptr csize;
-                      dst_sizes: ptr csize; buf: pointer): herr_t {.cdecl,
+                      nrecords: hsize_t; type_size: csize_t; dst_offset: ptr csize_t;
+                      dst_sizes: ptr csize_t; buf: pointer): herr_t {.cdecl,
     importc: "H5TBread_records", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Inquiry functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5TBget_table_info*(loc_id: hid_t; dset_name: cstring; nfields: ptr hsize_t;
                         nrecords: ptr hsize_t): herr_t {.cdecl,
     importc: "H5TBget_table_info", dynlib: libname_hl.}
 proc H5TBget_field_info*(loc_id: hid_t; dset_name: cstring; field_names: ptr cstring;
-                        field_sizes: ptr csize; field_offsets: ptr csize;
-                        type_size: ptr csize): herr_t {.cdecl,
+                        field_sizes: ptr csize_t; field_offsets: ptr csize_t;
+                        type_size: ptr csize_t): herr_t {.cdecl,
     importc: "H5TBget_field_info", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Manipulation functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5TBdelete_record*(loc_id: hid_t; dset_name: cstring; start: hsize_t;
                        nrecords: hsize_t): herr_t {.cdecl,
     importc: "H5TBdelete_record", dynlib: libname_hl.}
 proc H5TBinsert_record*(loc_id: hid_t; dset_name: cstring; start: hsize_t;
-                       nrecords: hsize_t; dst_size: csize; dst_offset: ptr csize;
-                       dst_sizes: ptr csize; buf: pointer): herr_t {.cdecl,
+                       nrecords: hsize_t; dst_size: csize_t_t; dst_offset: ptr csize_t_t;
+                       dst_sizes: ptr csize_t; buf: pointer): herr_t {.cdecl,
     importc: "H5TBinsert_record", dynlib: libname_hl.}
 proc H5TBadd_records_from*(loc_id: hid_t; dset_name1: cstring; start1: hsize_t;
                           nrecords: hsize_t; dset_name2: cstring; start2: hsize_t): herr_t {.
@@ -124,11 +124,11 @@ proc H5TBinsert_field*(loc_id: hid_t; dset_name: cstring; field_name: cstring;
 proc H5TBdelete_field*(loc_id: hid_t; dset_name: cstring; field_name: cstring): herr_t {.
     cdecl, importc: "H5TBdelete_field", dynlib: libname_hl.}
 ## -------------------------------------------------------------------------
-## 
+##
 ##  Table attribute functions
-## 
+##
 ## -------------------------------------------------------------------------
-## 
+##
 
 proc H5TBAget_title*(loc_id: hid_t; table_title: cstring): herr_t {.cdecl,
     importc: "H5TBAget_title", dynlib: libname_hl.}

--- a/src/nimhdf5/wrapper/H5ACpublic.nim
+++ b/src/nimhdf5/wrapper/H5ACpublic.nim
@@ -454,16 +454,16 @@ type
     trace_file_name*: array[H5AC_MAX_TRACE_FILE_NAME_LEN + 1, char]
     evictions_enabled*: hbool_t
     set_initial_size*: hbool_t
-    initial_size*: csize
+    initial_size*: csize_t
     min_clean_fraction*: cdouble
-    max_size*: csize
-    min_size*: csize
+    max_size*: csize_t
+    min_size*: csize_t
     epoch_length*: clong       ##  size increase control fields:
     incr_mode*: H5C_cache_incr_mode
     lower_hr_threshold*: cdouble
     increment*: cdouble
     apply_max_increment*: hbool_t
-    max_increment*: csize
+    max_increment*: csize_t
     flash_incr_mode*: H5C_cache_flash_incr_mode
     flash_multiple*: cdouble
     flash_threshold*: cdouble  ##  size decrease control fields:
@@ -471,11 +471,11 @@ type
     upper_hr_threshold*: cdouble
     decrement*: cdouble
     apply_max_decrement*: hbool_t
-    max_decrement*: csize
+    max_decrement*: csize_t
     epochs_before_eviction*: cint
     apply_empty_reserve*: hbool_t
     empty_reserve*: cdouble    ##  parallel configuration fields:
-    dirty_bytes_threshold*: csize
+    dirty_bytes_threshold*: csize_t
     metadata_write_strategy*: cint
 
 

--- a/src/nimhdf5/wrapper/H5Apublic.nim
+++ b/src/nimhdf5/wrapper/H5Apublic.nim
@@ -73,11 +73,11 @@ proc H5Aget_type*(attr_id: hid_t): hid_t {.cdecl, importc: "H5Aget_type",
                                        dynlib: libname.}
 proc H5Aget_create_plist*(attr_id: hid_t): hid_t {.cdecl,
     importc: "H5Aget_create_plist", dynlib: libname.}
-proc H5Aget_name*(attr_id: hid_t; buf_size: csize; buf: cstring): ssize_t {.cdecl,
+proc H5Aget_name*(attr_id: hid_t; buf_size: csize_t; buf: cstring): ssize_t {.cdecl,
     importc: "H5Aget_name", dynlib: libname.}
 proc H5Aget_name_by_idx*(loc_id: hid_t; obj_name: cstring; idx_type: H5_index_t;
                         order: H5_iter_order_t; n: hsize_t; name: cstring; ## out
-                        size: csize; lapl_id: hid_t): ssize_t {.cdecl,
+                        size: csize_t; lapl_id: hid_t): ssize_t {.cdecl,
     importc: "H5Aget_name_by_idx", dynlib: libname.}
 proc H5Aget_storage_size*(attr_id: hid_t): hsize_t {.cdecl,
     importc: "H5Aget_storage_size", dynlib: libname.}

--- a/src/nimhdf5/wrapper/H5Dpublic.nim
+++ b/src/nimhdf5/wrapper/H5Dpublic.nim
@@ -31,8 +31,8 @@ import
 ##  Macros used to "unset" chunk cache configuration parameters
 
 const
-  H5D_CHUNK_CACHE_NSLOTS_DEFAULT* = csize.high
-  H5D_CHUNK_CACHE_NBYTES_DEFAULT* = csize.high
+  H5D_CHUNK_CACHE_NSLOTS_DEFAULT* = csize_t.high
+  H5D_CHUNK_CACHE_NBYTES_DEFAULT* = csize_t.high
   H5D_CHUNK_CACHE_W0_DEFAULT* = (- 1.0)
 
 ##  Bit flags for the H5Pset_chunk_opts() and H5Pget_chunk_opts()
@@ -137,13 +137,13 @@ type
 
 type
   H5D_scatter_func_t* = proc (src_buf: ptr pointer; ## out
-                           src_buf_bytes_used: ptr csize; ## out
+                           src_buf_bytes_used: ptr csize_t; ## out
                            op_data: pointer): herr_t {.cdecl.}
 
 ##  Define the operator function pointer for H5Dgather()
 
 type
-  H5D_gather_func_t* = proc (dst_buf: pointer; dst_buf_bytes_used: csize;
+  H5D_gather_func_t* = proc (dst_buf: pointer; dst_buf_bytes_used: csize_t;
                           op_data: pointer): herr_t {.cdecl.}
 
 proc H5Dcreate2*(loc_id: hid_t; name: cstring; type_id: hid_t; space_id: hid_t;
@@ -195,7 +195,7 @@ proc H5Dscatter*(op: H5D_scatter_func_t; op_data: pointer; type_id: hid_t;
                 dst_space_id: hid_t; dst_buf: pointer): herr_t {.cdecl,
     importc: "H5Dscatter", dynlib: libname.}
 proc H5Dgather*(src_space_id: hid_t; src_buf: pointer; type_id: hid_t;
-               dst_buf_size: csize; dst_buf: pointer; op: H5D_gather_func_t;
+               dst_buf_size: csize_t; dst_buf: pointer; op: H5D_gather_func_t;
                op_data: pointer): herr_t {.cdecl, importc: "H5Dgather",
                                         dynlib: libname.}
 proc H5Ddebug*(dset_id: hid_t): herr_t {.cdecl, importc: "H5Ddebug", dynlib: libname.}

--- a/src/nimhdf5/wrapper/H5Epublic.nim
+++ b/src/nimhdf5/wrapper/H5Epublic.nim
@@ -181,14 +181,14 @@ proc H5Eget_current_stack*(): hid_t {.cdecl, importc: "H5Eget_current_stack",
                                    dynlib: libname.}
 proc H5Eclose_stack*(stack_id: hid_t): herr_t {.cdecl, importc: "H5Eclose_stack",
     dynlib: libname.}
-proc H5Eget_class_name*(class_id: hid_t; name: cstring; size: csize): ssize_t {.cdecl,
+proc H5Eget_class_name*(class_id: hid_t; name: cstring; size: csize_t): ssize_t {.cdecl,
     importc: "H5Eget_class_name", dynlib: libname.}
 proc H5Eset_current_stack*(err_stack_id: hid_t): herr_t {.cdecl,
     importc: "H5Eset_current_stack", dynlib: libname.}
 proc H5Epush2*(err_stack: hid_t; file: cstring; `func`: cstring; line: cuint;
               cls_id: hid_t; maj_id: hid_t; min_id: hid_t; msg: cstring): herr_t {.
     varargs, cdecl, importc: "H5Epush2", dynlib: libname.}
-proc H5Epop*(err_stack: hid_t; count: csize): herr_t {.cdecl, importc: "H5Epop",
+proc H5Epop*(err_stack: hid_t; count: csize_t): herr_t {.cdecl, importc: "H5Epop",
     dynlib: libname.}
 proc H5Eprint2*(err_stack: hid_t; stream: ptr FILE): herr_t {.cdecl,
     importc: "H5Eprint2", dynlib: libname.}
@@ -203,7 +203,7 @@ proc H5Eclear2*(err_stack: hid_t): herr_t {.cdecl, importc: "H5Eclear2",
                                         dynlib: libname.}
 proc H5Eauto_is_v2*(err_stack: hid_t; is_stack: ptr cuint): herr_t {.cdecl,
     importc: "H5Eauto_is_v2", dynlib: libname.}
-proc H5Eget_msg*(msg_id: hid_t; `type`: ptr H5E_type_t; msg: cstring; size: csize): ssize_t {.
+proc H5Eget_msg*(msg_id: hid_t; `type`: ptr H5E_type_t; msg: cstring; size: csize_t): ssize_t {.
     cdecl, importc: "H5Eget_msg", dynlib: libname.}
 proc H5Eget_num*(error_stack_id: hid_t): ssize_t {.cdecl, importc: "H5Eget_num",
     dynlib: libname.}

--- a/src/nimhdf5/wrapper/H5FDcore.nim
+++ b/src/nimhdf5/wrapper/H5FDcore.nim
@@ -23,9 +23,9 @@ import ../H5nimtypes, ../h5libname
 ##
 
 proc H5FD_core_init*(): hid_t {.cdecl, importc: "H5FD_core_init", dynlib: libname.}
-proc H5Pset_fapl_core*(fapl_id: hid_t; increment: csize; backing_store: hbool_t): herr_t {.
+proc H5Pset_fapl_core*(fapl_id: hid_t; increment: csize_t; backing_store: hbool_t): herr_t {.
     cdecl, importc: "H5Pset_fapl_core", dynlib: libname.}
-proc H5Pget_fapl_core*(fapl_id: hid_t; increment: ptr csize; ## out
+proc H5Pget_fapl_core*(fapl_id: hid_t; increment: ptr csize_t; ## out
                       backing_store: ptr hbool_t): herr_t {.cdecl,
     importc: "H5Pget_fapl_core", dynlib: libname.}
   ## out

--- a/src/nimhdf5/wrapper/H5FDdirect.nim
+++ b/src/nimhdf5/wrapper/H5FDdirect.nim
@@ -35,11 +35,11 @@ when defined(H5_HAVE_DIRECT):
     CBSIZE_DEF* = 16 * 1024 * 1024
   proc H5FD_direct_init*(): hid_t {.cdecl, importc: "H5FD_direct_init",
                                  dynlib: libname.}
-  proc H5Pset_fapl_direct*(fapl_id: hid_t; alignment: csize; block_size: csize;
-                          cbuf_size: csize): herr_t {.cdecl,
+  proc H5Pset_fapl_direct*(fapl_id: hid_t; alignment: csize_t; block_size: csize_t;
+                          cbuf_size: csize_t): herr_t {.cdecl,
       importc: "H5Pset_fapl_direct", dynlib: libname.}
-  proc H5Pget_fapl_direct*(fapl_id: hid_t; boundary: ptr csize; ## out
-                          block_size: ptr csize; ## out
-                          cbuf_size: ptr csize): herr_t {.cdecl,
+  proc H5Pget_fapl_direct*(fapl_id: hid_t; boundary: ptr csize_t; ## out
+                          block_size: ptr csize_t; ## out
+                          cbuf_size: ptr csize_t): herr_t {.cdecl,
       importc: "H5Pget_fapl_direct", dynlib: libname.}
     ## out

--- a/src/nimhdf5/wrapper/H5FDlog.nim
+++ b/src/nimhdf5/wrapper/H5FDlog.nim
@@ -85,7 +85,7 @@ const
 
 proc H5FD_log_init*(): hid_t {.cdecl, importc: "H5FD_log_init", dynlib: libname.}
 proc H5Pset_fapl_log*(fapl_id: hid_t; logfile: cstring; flags: culonglong;
-                     buf_size: csize): herr_t {.cdecl, importc: "H5Pset_fapl_log",
+                     buf_size: csize_t): herr_t {.cdecl, importc: "H5Pset_fapl_log",
     dynlib: libname.}
 
 let

--- a/src/nimhdf5/wrapper/H5FDpublic.nim
+++ b/src/nimhdf5/wrapper/H5FDpublic.nim
@@ -335,11 +335,11 @@ type
     sb_encode*: proc (file: ptr H5FD_t_prot; name: cstring; ## out
                     p: ptr cuchar): herr_t {.cdecl.} ## out
     sb_decode*: proc (f: ptr H5FD_t_prot; name: cstring; p: ptr cuchar): herr_t {.cdecl.}
-    fapl_size*: csize
+    fapl_size*: csize_t
     fapl_get*: proc (file: ptr H5FD_t_prot): pointer {.cdecl.}
     fapl_copy*: proc (fapl: pointer): pointer {.cdecl.}
     fapl_free*: proc (fapl: pointer): herr_t {.cdecl.}
-    dxpl_size*: csize
+    dxpl_size*: csize_t
     dxpl_copy*: proc (dxpl: pointer): pointer {.cdecl.}
     dxpl_free*: proc (dxpl: pointer): herr_t {.cdecl.}
     open*: proc (name: cstring; flags: cuint; fapl: hid_t; maxaddr: haddr_t): ptr H5FD_t_prot {.
@@ -358,9 +358,9 @@ type
     get_handle*: proc (file: ptr H5FD_t_prot; fapl: hid_t; file_handle: ptr pointer): herr_t {.
         cdecl.}
     read*: proc (file: ptr H5FD_t_prot; `type`: H5FD_mem_t; dxpl: hid_t; `addr`: haddr_t;
-               size: csize; buffer: pointer): herr_t {.cdecl.}
+               size: csize_t; buffer: pointer): herr_t {.cdecl.}
     write*: proc (file: ptr H5FD_t_prot; `type`: H5FD_mem_t; dxpl: hid_t; `addr`: haddr_t;
-                size: csize; buffer: pointer): herr_t {.cdecl.}
+                size: csize_t; buffer: pointer): herr_t {.cdecl.}
     flush*: proc (file: ptr H5FD_t_prot; dxpl_id: hid_t; closing: hbool_t): herr_t {.cdecl.}
     truncate*: proc (file: ptr H5FD_t_prot; dxpl_id: hid_t; closing: hbool_t): herr_t {.cdecl.}
     lock*: proc (file: ptr H5FD_t_prot; rw: hbool_t): herr_t {.cdecl.}
@@ -395,12 +395,12 @@ type
 
 type
   H5FD_file_image_callbacks_t* = object
-    image_malloc*: proc (size: csize; file_image_op: H5FD_file_image_op_t;
+    image_malloc*: proc (size: csize_t; file_image_op: H5FD_file_image_op_t;
                        udata: pointer): pointer {.cdecl.}
-    image_memcpy*: proc (dest: pointer; src: pointer; size: csize;
+    image_memcpy*: proc (dest: pointer; src: pointer; size: csize_t;
                        file_image_op: H5FD_file_image_op_t; udata: pointer): pointer {.
         cdecl.}
-    image_realloc*: proc (`ptr`: pointer; size: csize;
+    image_realloc*: proc (`ptr`: pointer; size: csize_t;
                         file_image_op: H5FD_file_image_op_t; udata: pointer): pointer {.
         cdecl.}
     image_free*: proc (`ptr`: pointer; file_image_op: H5FD_file_image_op_t;
@@ -436,11 +436,11 @@ proc H5FDget_eof*(file: ptr H5FD_t; `type`: H5FD_mem_t): haddr_t {.cdecl,
 proc H5FDget_vfd_handle*(file: ptr H5FD_t; fapl: hid_t; file_handle: ptr pointer): herr_t {.
     cdecl, importc: "H5FDget_vfd_handle", dynlib: libname.}
 proc H5FDread*(file: ptr H5FD_t; `type`: H5FD_mem_t; dxpl_id: hid_t; `addr`: haddr_t;
-              size: csize; buf: pointer): herr_t {.cdecl, importc: "H5FDread",
+              size: csize_t; buf: pointer): herr_t {.cdecl, importc: "H5FDread",
     dynlib: libname.}
   ## out
 proc H5FDwrite*(file: ptr H5FD_t; `type`: H5FD_mem_t; dxpl_id: hid_t; `addr`: haddr_t;
-               size: csize; buf: pointer): herr_t {.cdecl, importc: "H5FDwrite",
+               size: csize_t; buf: pointer): herr_t {.cdecl, importc: "H5FDwrite",
     dynlib: libname.}
 proc H5FDflush*(file: ptr H5FD_t; dxpl_id: hid_t; closing: hbool_t): herr_t {.cdecl,
     importc: "H5FDflush", dynlib: libname.}

--- a/src/nimhdf5/wrapper/H5Fpublic.nim
+++ b/src/nimhdf5/wrapper/H5Fpublic.nim
@@ -266,7 +266,7 @@ proc H5Fget_intent*(file_id: hid_t; intent: ptr cuint): herr_t {.cdecl,
     importc: "H5Fget_intent", dynlib: libname.}
 proc H5Fget_obj_count*(file_id: hid_t; types: cuint): ssize_t {.cdecl,
     importc: "H5Fget_obj_count", dynlib: libname.}
-proc H5Fget_obj_ids*(file_id: hid_t; types: cuint; max_objs: csize;
+proc H5Fget_obj_ids*(file_id: hid_t; types: cuint; max_objs: csize_t;
                     obj_id_list: ptr hid_t): ssize_t {.cdecl,
     importc: "H5Fget_obj_ids", dynlib: libname.}
 proc H5Fget_vfd_handle*(file_id: hid_t; fapl: hid_t; file_handle: ptr pointer): herr_t {.
@@ -279,7 +279,7 @@ proc H5Fget_freespace*(file_id: hid_t): hssize_t {.cdecl,
     importc: "H5Fget_freespace", dynlib: libname.}
 proc H5Fget_filesize*(file_id: hid_t; size: ptr hsize_t): herr_t {.cdecl,
     importc: "H5Fget_filesize", dynlib: libname.}
-proc H5Fget_file_image*(file_id: hid_t; buf_ptr: pointer; buf_len: csize): ssize_t {.
+proc H5Fget_file_image*(file_id: hid_t; buf_ptr: pointer; buf_len: csize_t): ssize_t {.
     cdecl, importc: "H5Fget_file_image", dynlib: libname.}
 proc H5Fget_mdc_config*(file_id: hid_t; config_ptr: ptr H5AC_cache_config_t): herr_t {.
     cdecl, importc: "H5Fget_mdc_config", dynlib: libname.}
@@ -287,13 +287,13 @@ proc H5Fset_mdc_config*(file_id: hid_t; config_ptr: ptr H5AC_cache_config_t): he
     cdecl, importc: "H5Fset_mdc_config", dynlib: libname.}
 proc H5Fget_mdc_hit_rate*(file_id: hid_t; hit_rate_ptr: ptr cdouble): herr_t {.cdecl,
     importc: "H5Fget_mdc_hit_rate", dynlib: libname.}
-proc H5Fget_mdc_size*(file_id: hid_t; max_size_ptr: ptr csize;
-                     min_clean_size_ptr: ptr csize; cur_size_ptr: ptr csize;
+proc H5Fget_mdc_size*(file_id: hid_t; max_size_ptr: ptr csize_t;
+                     min_clean_size_ptr: ptr csize_t; cur_size_ptr: ptr csize_t;
                      cur_num_entries_ptr: ptr cint): herr_t {.cdecl,
     importc: "H5Fget_mdc_size", dynlib: libname.}
 proc H5Freset_mdc_hit_rate_stats*(file_id: hid_t): herr_t {.cdecl,
     importc: "H5Freset_mdc_hit_rate_stats", dynlib: libname.}
-proc H5Fget_name*(obj_id: hid_t; name: cstring; size: csize): ssize_t {.cdecl,
+proc H5Fget_name*(obj_id: hid_t; name: cstring; size: csize_t): ssize_t {.cdecl,
     importc: "H5Fget_name", dynlib: libname.}
 proc H5Fget_info2*(obj_id: hid_t; finfo: ptr H5F_info2_t): herr_t {.cdecl,
     importc: "H5Fget_info2", dynlib: libname.}
@@ -301,7 +301,7 @@ proc H5Fget_metadata_read_retry_info*(file_id: hid_t; info: ptr H5F_retry_info_t
     cdecl, importc: "H5Fget_metadata_read_retry_info", dynlib: libname.}
 proc H5Fstart_swmr_write*(file_id: hid_t): herr_t {.cdecl,
     importc: "H5Fstart_swmr_write", dynlib: libname.}
-proc H5Fget_free_sections*(file_id: hid_t; `type`: H5F_mem_t; nsects: csize; sect_info: ptr H5F_sect_info_t): ssize_t {.
+proc H5Fget_free_sections*(file_id: hid_t; `type`: H5F_mem_t; nsects: csize_t; sect_info: ptr H5F_sect_info_t): ssize_t {.
     cdecl, importc: "H5Fget_free_sections", dynlib: libname.}
   ## out
 proc H5Fclear_elink_file_cache*(file_id: hid_t): herr_t {.cdecl,

--- a/src/nimhdf5/wrapper/H5Gpublic.nim
+++ b/src/nimhdf5/wrapper/H5Gpublic.nim
@@ -150,11 +150,11 @@ when not defined(H5_NO_DEPRECATED_SYMBOLS):
       nlink*: cuint            ## number of hard links to object
       `type`*: H5G_obj_t       ## basic object type
       mtime*: time_t           ## modification time
-      linklen*: csize          ## symbolic link value length
+      linklen*: csize_t          ## symbolic link value length
       ohdr*: H5O_stat_t        ##  Object header information
 
   ##  Function prototypes
-  proc H5Gcreate1*(loc_id: hid_t; name: cstring; size_hint: csize): hid_t {.cdecl,
+  proc H5Gcreate1*(loc_id: hid_t; name: cstring; size_hint: csize_t): hid_t {.cdecl,
       importc: "H5Gcreate1", dynlib: libname.}
   proc H5Gopen1*(loc_id: hid_t; name: cstring): hid_t {.cdecl, importc: "H5Gopen1",
       dynlib: libname.}
@@ -174,12 +174,12 @@ when not defined(H5_NO_DEPRECATED_SYMBOLS):
       dynlib: libname.}
   proc H5Gunlink*(loc_id: hid_t; name: cstring): herr_t {.cdecl, importc: "H5Gunlink",
       dynlib: libname.}
-  proc H5Gget_linkval*(loc_id: hid_t; name: cstring; size: csize; buf: cstring): herr_t {.
+  proc H5Gget_linkval*(loc_id: hid_t; name: cstring; size: csize_t; buf: cstring): herr_t {.
       cdecl, importc: "H5Gget_linkval", dynlib: libname.}
     ## out
   proc H5Gset_comment*(loc_id: hid_t; name: cstring; comment: cstring): herr_t {.cdecl,
       importc: "H5Gset_comment", dynlib: libname.}
-  proc H5Gget_comment*(loc_id: hid_t; name: cstring; bufsize: csize; buf: cstring): cint {.
+  proc H5Gget_comment*(loc_id: hid_t; name: cstring; bufsize: csize_t; buf: cstring): cint {.
       cdecl, importc: "H5Gget_comment", dynlib: libname.}
   proc H5Giterate*(loc_id: hid_t; name: cstring; idx: ptr cint; op: H5G_iterate_t;
                   op_data: pointer): herr_t {.cdecl, importc: "H5Giterate",
@@ -189,7 +189,7 @@ when not defined(H5_NO_DEPRECATED_SYMBOLS):
   proc H5Gget_objinfo*(loc_id: hid_t; name: cstring; follow_link: hbool_t; statbuf: ptr H5G_stat_t): herr_t {.
       cdecl, importc: "H5Gget_objinfo", dynlib: libname.}
     ## out
-  proc H5Gget_objname_by_idx*(loc_id: hid_t; idx: hsize_t; name: cstring; size: csize): ssize_t {.
+  proc H5Gget_objname_by_idx*(loc_id: hid_t; idx: hsize_t; name: cstring; size: csize_t): ssize_t {.
       cdecl, importc: "H5Gget_objname_by_idx", dynlib: libname.}
   proc H5Gget_objtype_by_idx*(loc_id: hid_t; idx: hsize_t): H5G_obj_t {.cdecl,
       importc: "H5Gget_objtype_by_idx", dynlib: libname.}

--- a/src/nimhdf5/wrapper/H5Ipublic.nim
+++ b/src/nimhdf5/wrapper/H5Ipublic.nim
@@ -99,12 +99,12 @@ proc H5Iget_type*(id: hid_t): H5I_type_t {.cdecl, importc: "H5Iget_type",
 proc H5Iget_file_id*(id: hid_t): hid_t {.cdecl, importc: "H5Iget_file_id",
                                      dynlib: libname.}
 proc H5Iget_name*(id: hid_t; name: cstring; ## out
-                 size: csize): ssize_t {.cdecl, importc: "H5Iget_name",
+                 size: csize_t): ssize_t {.cdecl, importc: "H5Iget_name",
                                       dynlib: libname.}
 proc H5Iinc_ref*(id: hid_t): cint {.cdecl, importc: "H5Iinc_ref", dynlib: libname.}
 proc H5Idec_ref*(id: hid_t): cint {.cdecl, importc: "H5Idec_ref", dynlib: libname.}
 proc H5Iget_ref*(id: hid_t): cint {.cdecl, importc: "H5Iget_ref", dynlib: libname.}
-proc H5Iregister_type*(hash_size: csize; reserved: cuint; free_func: H5I_free_t): H5I_type_t {.
+proc H5Iregister_type*(hash_size: csize_t; reserved: cuint; free_func: H5I_free_t): H5I_type_t {.
     cdecl, importc: "H5Iregister_type", dynlib: libname.}
 proc H5Iclear_type*(`type`: H5I_type_t; force: hbool_t): herr_t {.cdecl,
     importc: "H5Iclear_type", dynlib: libname.}

--- a/src/nimhdf5/wrapper/H5Lpublic.nim
+++ b/src/nimhdf5/wrapper/H5Lpublic.nim
@@ -86,7 +86,7 @@ const
 type
   INNER_C_UNION_3734014316* = object {.union.}
     address*: haddr_t          ##  Address hard link points to
-    val_size*: csize           ##  Size of a soft link or UD link value
+    val_size*: csize_t           ##  Size of a soft link or UD link value
 
   H5L_info_t* = object
     `type`*: H5L_type_t        ##  Type of link
@@ -105,38 +105,38 @@ type
 
 type
   H5L_create_func_t* = proc (link_name: cstring; loc_group: hid_t; lnkdata: pointer;
-                          lnkdata_size: csize; lcpl_id: hid_t): herr_t {.cdecl.}
+                          lnkdata_size: csize_t; lcpl_id: hid_t): herr_t {.cdecl.}
 
 ##  Callback for when the link is moved
 
 type
   H5L_move_func_t* = proc (new_name: cstring; new_loc: hid_t; lnkdata: pointer;
-                        lnkdata_size: csize): herr_t {.cdecl.}
+                        lnkdata_size: csize_t): herr_t {.cdecl.}
 
 ##  Callback for when the link is copied
 
 type
   H5L_copy_func_t* = proc (new_name: cstring; new_loc: hid_t; lnkdata: pointer;
-                        lnkdata_size: csize): herr_t {.cdecl.}
+                        lnkdata_size: csize_t): herr_t {.cdecl.}
 
 ##  Callback during link traversal
 
 type
   H5L_traverse_func_t* = proc (link_name: cstring; cur_group: hid_t; lnkdata: pointer;
-                            lnkdata_size: csize; lapl_id: hid_t): hid_t {.cdecl.}
+                            lnkdata_size: csize_t; lapl_id: hid_t): hid_t {.cdecl.}
 
 ##  Callback for when the link is deleted
 
 type
   H5L_delete_func_t* = proc (link_name: cstring; file: hid_t; lnkdata: pointer;
-                          lnkdata_size: csize): herr_t {.cdecl.}
+                          lnkdata_size: csize_t): herr_t {.cdecl.}
 
 ##  Callback for querying the link
 ##  Returns the size of the buffer needed
 
 type
-  H5L_query_func_t* = proc (link_name: cstring; lnkdata: pointer; lnkdata_size: csize; buf: pointer; ## out
-                         buf_size: csize): ssize_t {.cdecl.}
+  H5L_query_func_t* = proc (link_name: cstring; lnkdata: pointer; lnkdata_size: csize_t; buf: pointer; ## out
+                         buf_size: csize_t): ssize_t {.cdecl.}
 
 ##  User-defined link types
 
@@ -192,11 +192,11 @@ proc H5Ldelete_by_idx*(loc_id: hid_t; group_name: cstring; idx_type: H5_index_t;
                       order: H5_iter_order_t; n: hsize_t; lapl_id: hid_t): herr_t {.
     cdecl, importc: "H5Ldelete_by_idx", dynlib: libname.}
 proc H5Lget_val*(loc_id: hid_t; name: cstring; buf: pointer; ## out
-                size: csize; lapl_id: hid_t): herr_t {.cdecl, importc: "H5Lget_val",
+                size: csize_t; lapl_id: hid_t): herr_t {.cdecl, importc: "H5Lget_val",
     dynlib: libname.}
 proc H5Lget_val_by_idx*(loc_id: hid_t; group_name: cstring; idx_type: H5_index_t;
                        order: H5_iter_order_t; n: hsize_t; buf: pointer; ## out
-                       size: csize; lapl_id: hid_t): herr_t {.cdecl,
+                       size: csize_t; lapl_id: hid_t): herr_t {.cdecl,
     importc: "H5Lget_val_by_idx", dynlib: libname.}
 proc H5Lexists*(loc_id: hid_t; name: cstring; lapl_id: hid_t): htri_t {.cdecl,
     importc: "H5Lexists", dynlib: libname.}
@@ -209,7 +209,7 @@ proc H5Lget_info_by_idx*(loc_id: hid_t; group_name: cstring; idx_type: H5_index_
     importc: "H5Lget_info_by_idx", dynlib: libname.}
 proc H5Lget_name_by_idx*(loc_id: hid_t; group_name: cstring; idx_type: H5_index_t;
                         order: H5_iter_order_t; n: hsize_t; name: cstring; ## out
-                        size: csize; lapl_id: hid_t): ssize_t {.cdecl,
+                        size: csize_t; lapl_id: hid_t): ssize_t {.cdecl,
     importc: "H5Lget_name_by_idx", dynlib: libname.}
 proc H5Literate*(grp_id: hid_t; idx_type: H5_index_t; order: H5_iter_order_t;
                 idx: ptr hsize_t; op: H5L_iterate_t; op_data: pointer): herr_t {.cdecl,
@@ -228,7 +228,7 @@ proc H5Lvisit_by_name*(loc_id: hid_t; group_name: cstring; idx_type: H5_index_t;
 ##  UD link functions
 
 proc H5Lcreate_ud*(link_loc_id: hid_t; link_name: cstring; link_type: H5L_type_t;
-                  udata: pointer; udata_size: csize; lcpl_id: hid_t; lapl_id: hid_t): herr_t {.
+                  udata: pointer; udata_size: csize_t; lcpl_id: hid_t; lapl_id: hid_t): herr_t {.
     cdecl, importc: "H5Lcreate_ud", dynlib: libname.}
 proc H5Lregister*(cls: ptr H5L_class_t): herr_t {.cdecl, importc: "H5Lregister",
     dynlib: libname.}
@@ -239,7 +239,7 @@ proc H5Lis_registered*(id: H5L_type_t): htri_t {.cdecl, importc: "H5Lis_register
 ##  External link functions
 
 proc H5Lunpack_elink_val*(ext_linkval: pointer; ## in
-                         link_size: csize; flags: ptr cuint; filename: cstringArray; ## out
+                         link_size: csize_t; flags: ptr cuint; filename: cstringArray; ## out
                          obj_path: cstringArray): herr_t {.cdecl,
     importc: "H5Lunpack_elink_val", dynlib: libname.}
   ## out

--- a/src/nimhdf5/wrapper/H5MMpublic.nim
+++ b/src/nimhdf5/wrapper/H5MMpublic.nim
@@ -35,5 +35,5 @@ import
 ##  These typedefs are currently used for VL datatype allocation/freeing
 
 type
-  H5MM_allocate_t* = proc (size: csize; alloc_info: pointer): pointer {.cdecl.}
+  H5MM_allocate_t* = proc (size: csize_t; alloc_info: pointer): pointer {.cdecl.}
   H5MM_free_t* = proc (mem: pointer; free_info: pointer) {.cdecl.}

--- a/src/nimhdf5/wrapper/H5Opublic.nim
+++ b/src/nimhdf5/wrapper/H5Opublic.nim
@@ -244,10 +244,10 @@ proc H5Oset_comment*(obj_id: hid_t; comment: cstring): herr_t {.cdecl,
 proc H5Oset_comment_by_name*(loc_id: hid_t; name: cstring; comment: cstring;
                             lapl_id: hid_t): herr_t {.cdecl,
     importc: "H5Oset_comment_by_name", dynlib: libname.}
-proc H5Oget_comment*(obj_id: hid_t; comment: cstring; bufsize: csize): ssize_t {.cdecl,
+proc H5Oget_comment*(obj_id: hid_t; comment: cstring; bufsize: csize_t): ssize_t {.cdecl,
     importc: "H5Oget_comment", dynlib: libname.}
 proc H5Oget_comment_by_name*(loc_id: hid_t; name: cstring; comment: cstring;
-                            bufsize: csize; lapl_id: hid_t): ssize_t {.cdecl,
+                            bufsize: csize_t; lapl_id: hid_t): ssize_t {.cdecl,
     importc: "H5Oget_comment_by_name", dynlib: libname.}
 when defined(H5_FUTURE):
   proc H5Ovisit*(obj_id: hid_t; idx_type: H5_index_t; order: H5_iter_order_t;

--- a/src/nimhdf5/wrapper/H5PLpublic.nim
+++ b/src/nimhdf5/wrapper/H5PLpublic.nim
@@ -59,7 +59,7 @@ proc H5PLinsert*(plugin_path: cstring; index: cuint): herr_t {.cdecl,
     importc: "H5PLinsert", dynlib: libname.}
 proc H5PLremove*(index: cuint): herr_t {.cdecl, importc: "H5PLremove", dynlib: libname.}
 proc H5PLget*(index: cuint; pathname: cstring; ## out
-             size: csize): ssize_t {.cdecl, importc: "H5PLget", dynlib: libname.}
+             size: csize_t): ssize_t {.cdecl, importc: "H5PLget", dynlib: libname.}
 proc H5PLsize*(listsize: ptr cuint): herr_t {.cdecl, importc: "H5PLsize",
     dynlib: libname.}
   ## out

--- a/src/nimhdf5/wrapper/H5Ppublic.nim
+++ b/src/nimhdf5/wrapper/H5Ppublic.nim
@@ -56,18 +56,18 @@ type
 ##  Define property list callback function pointer types
 
 type
-  H5P_prp_cb1_t* = proc (name: cstring; size: csize; value: pointer): herr_t {.cdecl.}
-  H5P_prp_cb2_t* = proc (prop_id: hid_t; name: cstring; size: csize; value: pointer): herr_t {.
+  H5P_prp_cb1_t* = proc (name: cstring; size: csize_t; value: pointer): herr_t {.cdecl.}
+  H5P_prp_cb2_t* = proc (prop_id: hid_t; name: cstring; size: csize_t; value: pointer): herr_t {.
       cdecl.}
   H5P_prp_create_func_t* = H5P_prp_cb1_t
   H5P_prp_set_func_t* = H5P_prp_cb2_t
   H5P_prp_get_func_t* = H5P_prp_cb2_t
-  H5P_prp_encode_func_t* = proc (value: pointer; buf: ptr pointer; size: ptr csize): herr_t {.
+  H5P_prp_encode_func_t* = proc (value: pointer; buf: ptr pointer; size: ptr csize_t): herr_t {.
       cdecl.}
   H5P_prp_decode_func_t* = proc (buf: ptr pointer; value: pointer): herr_t {.cdecl.}
   H5P_prp_delete_func_t* = H5P_prp_cb2_t
   H5P_prp_copy_func_t* = H5P_prp_cb1_t
-  H5P_prp_compare_func_t* = proc (value1: pointer; value2: pointer; size: csize): cint {.
+  H5P_prp_compare_func_t* = proc (value1: pointer; value2: pointer; size: csize_t): cint {.
       cdecl.}
   H5P_prp_close_func_t* = H5P_prp_cb1_t
 
@@ -430,13 +430,13 @@ proc H5Pcreate_class*(parent: hid_t; name: cstring;
 proc H5Pget_class_name*(pclass_id: hid_t): cstring {.cdecl,
     importc: "H5Pget_class_name", dynlib: libname.}
 proc H5Pcreate*(cls_id: hid_t): hid_t {.cdecl, importc: "H5Pcreate", dynlib: libname.}
-proc H5Pregister2*(cls_id: hid_t; name: cstring; size: csize; def_value: pointer;
+proc H5Pregister2*(cls_id: hid_t; name: cstring; size: csize_t; def_value: pointer;
                   prp_create: H5P_prp_create_func_t; prp_set: H5P_prp_set_func_t;
                   prp_get: H5P_prp_get_func_t; prp_del: H5P_prp_delete_func_t;
                   prp_copy: H5P_prp_copy_func_t; prp_cmp: H5P_prp_compare_func_t;
                   prp_close: H5P_prp_close_func_t): herr_t {.cdecl,
     importc: "H5Pregister2", dynlib: libname.}
-proc H5Pinsert2*(plist_id: hid_t; name: cstring; size: csize; value: pointer;
+proc H5Pinsert2*(plist_id: hid_t; name: cstring; size: csize_t; value: pointer;
                 prp_set: H5P_prp_set_func_t; prp_get: H5P_prp_get_func_t;
                 prp_delete: H5P_prp_delete_func_t; prp_copy: H5P_prp_copy_func_t;
                 prp_cmp: H5P_prp_compare_func_t; prp_close: H5P_prp_close_func_t): herr_t {.
@@ -445,12 +445,12 @@ proc H5Pset*(plist_id: hid_t; name: cstring; value: pointer): herr_t {.cdecl,
     importc: "H5Pset", dynlib: libname.}
 proc H5Pexist*(plist_id: hid_t; name: cstring): htri_t {.cdecl, importc: "H5Pexist",
     dynlib: libname.}
-proc H5Pencode*(plist_id: hid_t; buf: pointer; nalloc: ptr csize): herr_t {.cdecl,
+proc H5Pencode*(plist_id: hid_t; buf: pointer; nalloc: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pencode", dynlib: libname.}
 proc H5Pdecode*(buf: pointer): hid_t {.cdecl, importc: "H5Pdecode", dynlib: libname.}
-proc H5Pget_size*(id: hid_t; name: cstring; size: ptr csize): herr_t {.cdecl,
+proc H5Pget_size*(id: hid_t; name: cstring; size: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_size", dynlib: libname.}
-proc H5Pget_nprops*(id: hid_t; nprops: ptr csize): herr_t {.cdecl,
+proc H5Pget_nprops*(id: hid_t; nprops: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_nprops", dynlib: libname.}
 proc H5Pget_class*(plist_id: hid_t): hid_t {.cdecl, importc: "H5Pget_class",
     dynlib: libname.}
@@ -490,24 +490,24 @@ proc H5Pset_obj_track_times*(plist_id: hid_t; track_times: hbool_t): herr_t {.cd
 proc H5Pget_obj_track_times*(plist_id: hid_t; track_times: ptr hbool_t): herr_t {.
     cdecl, importc: "H5Pget_obj_track_times", dynlib: libname.}
 proc H5Pmodify_filter*(plist_id: hid_t; filter: H5Z_filter_t; flags: cuint;
-                      cd_nelmts: csize; cd_values: ptr cuint): herr_t {.cdecl,
+                      cd_nelmts: csize_t; cd_values: ptr cuint): herr_t {.cdecl,
     importc: "H5Pmodify_filter", dynlib: libname.}
   ## cd_nelmts
 proc H5Pset_filter*(plist_id: hid_t; filter: H5Z_filter_t; flags: cuint;
-                   cd_nelmts: csize; c_values: ptr cuint): herr_t {.cdecl,
+                   cd_nelmts: csize_t; c_values: ptr cuint): herr_t {.cdecl,
     importc: "H5Pset_filter", dynlib: libname.}
 proc H5Pget_nfilters*(plist_id: hid_t): cint {.cdecl, importc: "H5Pget_nfilters",
     dynlib: libname.}
 proc H5Pget_filter2*(plist_id: hid_t; filter: cuint; flags: ptr cuint; ## out
-                    cd_nelmts: ptr csize; ## out
+                    cd_nelmts: ptr csize_t; ## out
                     cd_values: ptr cuint; ## out
-                    namelen: csize; name: ptr char; filter_config: ptr cuint): H5Z_filter_t {.
+                    namelen: csize_t; name: ptr char; filter_config: ptr cuint): H5Z_filter_t {.
     cdecl, importc: "H5Pget_filter2", dynlib: libname.}
   ## out
 proc H5Pget_filter_by_id2*(plist_id: hid_t; id: H5Z_filter_t; flags: ptr cuint; ## out
-                          cd_nelmts: ptr csize; ## out
+                          cd_nelmts: ptr csize_t; ## out
                           cd_values: ptr cuint; ## out
-                          namelen: csize; name: ptr char; ## out
+                          namelen: csize_t; name: ptr char; ## out
                           filter_config: ptr cuint): herr_t {.cdecl,
     importc: "H5Pget_filter_by_id2", dynlib: libname.}
   ## out
@@ -525,10 +525,10 @@ proc H5Pset_userblock*(plist_id: hid_t; size: hsize_t): herr_t {.cdecl,
     importc: "H5Pset_userblock", dynlib: libname.}
 proc H5Pget_userblock*(plist_id: hid_t; size: ptr hsize_t): herr_t {.cdecl,
     importc: "H5Pget_userblock", dynlib: libname.}
-proc H5Pset_sizes*(plist_id: hid_t; sizeof_addr: csize; sizeof_size: csize): herr_t {.
+proc H5Pset_sizes*(plist_id: hid_t; sizeof_addr: csize_t; sizeof_size: csize_t): herr_t {.
     cdecl, importc: "H5Pset_sizes", dynlib: libname.}
-proc H5Pget_sizes*(plist_id: hid_t; sizeof_addr: ptr csize; ## out
-                  sizeof_size: ptr csize): herr_t {.cdecl, importc: "H5Pget_sizes",
+proc H5Pget_sizes*(plist_id: hid_t; sizeof_addr: ptr csize_t; ## out
+                  sizeof_size: ptr csize_t): herr_t {.cdecl, importc: "H5Pget_sizes",
     dynlib: libname.}
   ## out
 proc H5Pset_sym_k*(plist_id: hid_t; ik: cuint; lk: cuint): herr_t {.cdecl,
@@ -591,12 +591,12 @@ proc H5Pset_multi_type*(fapl_id: hid_t; `type`: H5FD_mem_t): herr_t {.cdecl,
     importc: "H5Pset_multi_type", dynlib: libname.}
 proc H5Pget_multi_type*(fapl_id: hid_t; `type`: ptr H5FD_mem_t): herr_t {.cdecl,
     importc: "H5Pget_multi_type", dynlib: libname.}
-proc H5Pset_cache*(plist_id: hid_t; mdc_nelmts: cint; rdcc_nslots: csize;
-                  rdcc_nbytes: csize; rdcc_w0: cdouble): herr_t {.cdecl,
+proc H5Pset_cache*(plist_id: hid_t; mdc_nelmts: cint; rdcc_nslots: csize_t;
+                  rdcc_nbytes: csize_t; rdcc_w0: cdouble): herr_t {.cdecl,
     importc: "H5Pset_cache", dynlib: libname.}
-proc H5Pget_cache*(plist_id: hid_t; mdc_nelmts: ptr cint; rdcc_nslots: ptr csize; ##  out
+proc H5Pget_cache*(plist_id: hid_t; mdc_nelmts: ptr cint; rdcc_nslots: ptr csize_t; ##  out
 ## out
-                  rdcc_nbytes: ptr csize; ## out
+                  rdcc_nbytes: ptr csize_t; ## out
                   rdcc_w0: ptr cdouble): herr_t {.cdecl, importc: "H5Pget_cache",
     dynlib: libname.}
 proc H5Pset_mdc_config*(plist_id: hid_t; config_ptr: ptr H5AC_cache_config_t): herr_t {.
@@ -619,9 +619,9 @@ proc H5Pset_meta_block_size*(fapl_id: hid_t; size: hsize_t): herr_t {.cdecl,
 proc H5Pget_meta_block_size*(fapl_id: hid_t; size: ptr hsize_t): herr_t {.cdecl,
     importc: "H5Pget_meta_block_size", dynlib: libname.}
   ## out
-proc H5Pset_sieve_buf_size*(fapl_id: hid_t; size: csize): herr_t {.cdecl,
+proc H5Pset_sieve_buf_size*(fapl_id: hid_t; size: csize_t): herr_t {.cdecl,
     importc: "H5Pset_sieve_buf_size", dynlib: libname.}
-proc H5Pget_sieve_buf_size*(fapl_id: hid_t; size: ptr csize): herr_t {.cdecl,
+proc H5Pget_sieve_buf_size*(fapl_id: hid_t; size: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_sieve_buf_size", dynlib: libname.}
   ## out
 proc H5Pset_small_data_block_size*(fapl_id: hid_t; size: hsize_t): herr_t {.cdecl,
@@ -638,10 +638,10 @@ proc H5Pset_elink_file_cache_size*(plist_id: hid_t; efc_size: cuint): herr_t {.c
     importc: "H5Pset_elink_file_cache_size", dynlib: libname.}
 proc H5Pget_elink_file_cache_size*(plist_id: hid_t; efc_size: ptr cuint): herr_t {.
     cdecl, importc: "H5Pget_elink_file_cache_size", dynlib: libname.}
-proc H5Pset_file_image*(fapl_id: hid_t; buf_ptr: pointer; buf_len: csize): herr_t {.
+proc H5Pset_file_image*(fapl_id: hid_t; buf_ptr: pointer; buf_len: csize_t): herr_t {.
     cdecl, importc: "H5Pset_file_image", dynlib: libname.}
 proc H5Pget_file_image*(fapl_id: hid_t; buf_ptr_ptr: ptr pointer;
-                       buf_len_ptr: ptr csize): herr_t {.cdecl,
+                       buf_len_ptr: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_file_image", dynlib: libname.}
 proc H5Pset_file_image_callbacks*(fapl_id: hid_t;
                                  callbacks_ptr: ptr H5FD_file_image_callbacks_t): herr_t {.
@@ -650,10 +650,10 @@ proc H5Pget_file_image_callbacks*(fapl_id: hid_t;
                                  callbacks_ptr: ptr H5FD_file_image_callbacks_t): herr_t {.
     cdecl, importc: "H5Pget_file_image_callbacks", dynlib: libname.}
 proc H5Pset_core_write_tracking*(fapl_id: hid_t; is_enabled: hbool_t;
-                                page_size: csize): herr_t {.cdecl,
+                                page_size: csize_t): herr_t {.cdecl,
     importc: "H5Pset_core_write_tracking", dynlib: libname.}
 proc H5Pget_core_write_tracking*(fapl_id: hid_t; is_enabled: ptr hbool_t;
-                                page_size: ptr csize): herr_t {.cdecl,
+                                page_size: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_core_write_tracking", dynlib: libname.}
 proc H5Pset_metadata_read_attempts*(plist_id: hid_t; attempts: cuint): herr_t {.cdecl,
     importc: "H5Pset_metadata_read_attempts", dynlib: libname.}
@@ -668,7 +668,7 @@ proc H5Pset_mdc_log_options*(plist_id: hid_t; is_enabled: hbool_t; location: cst
                             start_on_access: hbool_t): herr_t {.cdecl,
     importc: "H5Pset_mdc_log_options", dynlib: libname.}
 proc H5Pget_mdc_log_options*(plist_id: hid_t; is_enabled: ptr hbool_t;
-                            location: cstring; location_size: ptr csize;
+                            location: cstring; location_size: ptr csize_t;
                             start_on_access: ptr hbool_t): herr_t {.cdecl,
     importc: "H5Pget_mdc_log_options", dynlib: libname.}
 proc H5Pset_evict_on_close*(fapl_id: hid_t; evict_on_close: hbool_t): herr_t {.cdecl,
@@ -690,10 +690,10 @@ proc H5Pset_mdc_image_config*(plist_id: hid_t;
 proc H5Pget_mdc_image_config*(plist_id: hid_t; config_ptr: ptr H5AC_cache_image_config_t): herr_t {.
     cdecl, importc: "H5Pget_mdc_image_config", dynlib: libname.}
   ## out
-proc H5Pset_page_buffer_size*(plist_id: hid_t; buf_size: csize; min_meta_per: cuint;
+proc H5Pset_page_buffer_size*(plist_id: hid_t; buf_size: csize_t; min_meta_per: cuint;
                              min_raw_per: cuint): herr_t {.cdecl,
     importc: "H5Pset_page_buffer_size", dynlib: libname.}
-proc H5Pget_page_buffer_size*(plist_id: hid_t; buf_size: ptr csize;
+proc H5Pget_page_buffer_size*(plist_id: hid_t; buf_size: ptr csize_t;
                              min_meta_per: ptr cuint; min_raw_per: ptr cuint): herr_t {.
     cdecl, importc: "H5Pget_page_buffer_size", dynlib: libname.}
 ##  Dataset creation property list (DCPL) routines
@@ -711,18 +711,18 @@ proc H5Pget_chunk*(plist_id: hid_t; max_ndims: cint; dim: ptr hsize_t): cint {.c
 proc H5Pset_virtual*(dcpl_id: hid_t; vspace_id: hid_t; src_file_name: cstring;
                     src_dset_name: cstring; src_space_id: hid_t): herr_t {.cdecl,
     importc: "H5Pset_virtual", dynlib: libname.}
-proc H5Pget_virtual_count*(dcpl_id: hid_t; count: ptr csize): herr_t {.cdecl,
+proc H5Pget_virtual_count*(dcpl_id: hid_t; count: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_virtual_count", dynlib: libname.}
   ## out
-proc H5Pget_virtual_vspace*(dcpl_id: hid_t; index: csize): hid_t {.cdecl,
+proc H5Pget_virtual_vspace*(dcpl_id: hid_t; index: csize_t): hid_t {.cdecl,
     importc: "H5Pget_virtual_vspace", dynlib: libname.}
-proc H5Pget_virtual_srcspace*(dcpl_id: hid_t; index: csize): hid_t {.cdecl,
+proc H5Pget_virtual_srcspace*(dcpl_id: hid_t; index: csize_t): hid_t {.cdecl,
     importc: "H5Pget_virtual_srcspace", dynlib: libname.}
-proc H5Pget_virtual_filename*(dcpl_id: hid_t; index: csize; name: cstring; ## out
-                             size: csize): ssize_t {.cdecl,
+proc H5Pget_virtual_filename*(dcpl_id: hid_t; index: csize_t; name: cstring; ## out
+                             size: csize_t): ssize_t {.cdecl,
     importc: "H5Pget_virtual_filename", dynlib: libname.}
-proc H5Pget_virtual_dsetname*(dcpl_id: hid_t; index: csize; name: cstring; ## out
-                             size: csize): ssize_t {.cdecl,
+proc H5Pget_virtual_dsetname*(dcpl_id: hid_t; index: csize_t; name: cstring; ## out
+                             size: csize_t): ssize_t {.cdecl,
     importc: "H5Pget_virtual_dsetname", dynlib: libname.}
 proc H5Pset_external*(plist_id: hid_t; name: cstring; offset: off_t; size: hsize_t): herr_t {.
     cdecl, importc: "H5Pset_external", dynlib: libname.}
@@ -732,7 +732,7 @@ proc H5Pget_chunk_opts*(plist_id: hid_t; opts: ptr cuint): herr_t {.cdecl,
     importc: "H5Pget_chunk_opts", dynlib: libname.}
 proc H5Pget_external_count*(plist_id: hid_t): cint {.cdecl,
     importc: "H5Pget_external_count", dynlib: libname.}
-proc H5Pget_external*(plist_id: hid_t; idx: cuint; name_size: csize; name: cstring; ## out
+proc H5Pget_external*(plist_id: hid_t; idx: cuint; name_size: csize_t; name: cstring; ## out
                      offset: ptr off_t; ## out
                      size: ptr hsize_t): herr_t {.cdecl, importc: "H5Pget_external",
     dynlib: libname.}
@@ -765,11 +765,11 @@ proc H5Pget_fill_time*(plist_id: hid_t; fill_time: ptr H5D_fill_time_t): herr_t 
   ## out
 ##  Dataset access property list (DAPL) routines
 
-proc H5Pset_chunk_cache*(dapl_id: hid_t; rdcc_nslots: csize; rdcc_nbytes: csize;
+proc H5Pset_chunk_cache*(dapl_id: hid_t; rdcc_nslots: csize_t; rdcc_nbytes: csize_t;
                         rdcc_w0: cdouble): herr_t {.cdecl,
     importc: "H5Pset_chunk_cache", dynlib: libname.}
-proc H5Pget_chunk_cache*(dapl_id: hid_t; rdcc_nslots: ptr csize; ## out
-                        rdcc_nbytes: ptr csize; ## out
+proc H5Pget_chunk_cache*(dapl_id: hid_t; rdcc_nslots: ptr csize_t; ## out
+                        rdcc_nbytes: ptr csize_t; ## out
                         rdcc_w0: ptr cdouble): herr_t {.cdecl,
     importc: "H5Pget_chunk_cache", dynlib: libname.}
   ## out
@@ -790,19 +790,19 @@ proc H5Pget_append_flush*(plist_id: hid_t; dims: cuint; boundary: ptr hsize_t;
 proc H5Pset_efile_prefix*(dapl_id: hid_t; prefix: cstring): herr_t {.cdecl,
     importc: "H5Pset_efile_prefix", dynlib: libname.}
 proc H5Pget_efile_prefix*(dapl_id: hid_t; prefix: cstring; ## out
-                         size: csize): ssize_t {.cdecl,
+                         size: csize_t): ssize_t {.cdecl,
     importc: "H5Pget_efile_prefix", dynlib: libname.}
 ##  Dataset xfer property list (DXPL) routines
 
 proc H5Pset_data_transform*(plist_id: hid_t; expression: cstring): herr_t {.cdecl,
     importc: "H5Pset_data_transform", dynlib: libname.}
 proc H5Pget_data_transform*(plist_id: hid_t; expression: cstring; ## out
-                           size: csize): ssize_t {.cdecl,
+                           size: csize_t): ssize_t {.cdecl,
     importc: "H5Pget_data_transform", dynlib: libname.}
-proc H5Pset_buffer*(plist_id: hid_t; size: csize; tconv: pointer; bkg: pointer): herr_t {.
+proc H5Pset_buffer*(plist_id: hid_t; size: csize_t; tconv: pointer; bkg: pointer): herr_t {.
     cdecl, importc: "H5Pset_buffer", dynlib: libname.}
 proc H5Pget_buffer*(plist_id: hid_t; tconv: ptr pointer; ## out
-                   bkg: ptr pointer): csize {.cdecl, importc: "H5Pget_buffer",
+                   bkg: ptr pointer): csize_t {.cdecl, importc: "H5Pget_buffer",
     dynlib: libname.}
   ## out
 proc H5Pset_preserve*(plist_id: hid_t; status: hbool_t): herr_t {.cdecl,
@@ -832,9 +832,9 @@ proc H5Pget_vlen_mem_manager*(plist_id: hid_t; alloc_func: ptr H5MM_allocate_t;
                              alloc_info: ptr pointer; free_func: ptr H5MM_free_t;
                              free_info: ptr pointer): herr_t {.cdecl,
     importc: "H5Pget_vlen_mem_manager", dynlib: libname.}
-proc H5Pset_hyper_vector_size*(fapl_id: hid_t; size: csize): herr_t {.cdecl,
+proc H5Pset_hyper_vector_size*(fapl_id: hid_t; size: csize_t): herr_t {.cdecl,
     importc: "H5Pset_hyper_vector_size", dynlib: libname.}
-proc H5Pget_hyper_vector_size*(fapl_id: hid_t; size: ptr csize): herr_t {.cdecl,
+proc H5Pget_hyper_vector_size*(fapl_id: hid_t; size: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_hyper_vector_size", dynlib: libname.}
   ## out
 proc H5Pset_type_conv_cb*(dxpl_id: hid_t; op: H5T_conv_except_func_t;
@@ -863,9 +863,9 @@ proc H5Pget_create_intermediate_group*(plist_id: hid_t; crt_intmd: ptr cuint): h
   ## out
 ##  Group creation property list (GCPL) routines
 
-proc H5Pset_local_heap_size_hint*(plist_id: hid_t; size_hint: csize): herr_t {.cdecl,
+proc H5Pset_local_heap_size_hint*(plist_id: hid_t; size_hint: csize_t): herr_t {.cdecl,
     importc: "H5Pset_local_heap_size_hint", dynlib: libname.}
-proc H5Pget_local_heap_size_hint*(plist_id: hid_t; size_hint: ptr csize): herr_t {.
+proc H5Pget_local_heap_size_hint*(plist_id: hid_t; size_hint: ptr csize_t): herr_t {.
     cdecl, importc: "H5Pget_local_heap_size_hint", dynlib: libname.}
   ## out
 proc H5Pset_link_phase_change*(plist_id: hid_t; max_compact: cuint; min_dense: cuint): herr_t {.
@@ -895,13 +895,13 @@ proc H5Pget_char_encoding*(plist_id: hid_t; encoding: ptr H5T_cset_t): herr_t {.
   ## out
 ##  Link access property list (LAPL) routines
 
-proc H5Pset_nlinks*(plist_id: hid_t; nlinks: csize): herr_t {.cdecl,
+proc H5Pset_nlinks*(plist_id: hid_t; nlinks: csize_t): herr_t {.cdecl,
     importc: "H5Pset_nlinks", dynlib: libname.}
-proc H5Pget_nlinks*(plist_id: hid_t; nlinks: ptr csize): herr_t {.cdecl,
+proc H5Pget_nlinks*(plist_id: hid_t; nlinks: ptr csize_t): herr_t {.cdecl,
     importc: "H5Pget_nlinks", dynlib: libname.}
 proc H5Pset_elink_prefix*(plist_id: hid_t; prefix: cstring): herr_t {.cdecl,
     importc: "H5Pset_elink_prefix", dynlib: libname.}
-proc H5Pget_elink_prefix*(plist_id: hid_t; prefix: cstring; size: csize): ssize_t {.
+proc H5Pget_elink_prefix*(plist_id: hid_t; prefix: cstring; size: csize_t): ssize_t {.
     cdecl, importc: "H5Pget_elink_prefix", dynlib: libname.}
 proc H5Pget_elink_fapl*(lapl_id: hid_t): hid_t {.cdecl, importc: "H5Pget_elink_fapl",
     dynlib: libname.}
@@ -945,26 +945,26 @@ when not defined(H5_NO_DEPRECATED_SYMBOLS):
   #  H5P_NO_CLASS* = H5P_ROOT
   ##  Typedefs
   ##  Function prototypes
-  proc H5Pregister1*(cls_id: hid_t; name: cstring; size: csize; def_value: pointer;
+  proc H5Pregister1*(cls_id: hid_t; name: cstring; size: csize_t; def_value: pointer;
                     prp_create: H5P_prp_create_func_t;
                     prp_set: H5P_prp_set_func_t; prp_get: H5P_prp_get_func_t;
                     prp_del: H5P_prp_delete_func_t; prp_copy: H5P_prp_copy_func_t;
                     prp_close: H5P_prp_close_func_t): herr_t {.cdecl,
       importc: "H5Pregister1", dynlib: libname.}
-  proc H5Pinsert1*(plist_id: hid_t; name: cstring; size: csize; value: pointer;
+  proc H5Pinsert1*(plist_id: hid_t; name: cstring; size: csize_t; value: pointer;
                   prp_set: H5P_prp_set_func_t; prp_get: H5P_prp_get_func_t;
                   prp_delete: H5P_prp_delete_func_t;
                   prp_copy: H5P_prp_copy_func_t; prp_close: H5P_prp_close_func_t): herr_t {.
       cdecl, importc: "H5Pinsert1", dynlib: libname.}
   proc H5Pget_filter1*(plist_id: hid_t; filter: cuint; flags: ptr cuint; ## out
-                      cd_nelmts: ptr csize; ## out
+                      cd_nelmts: ptr csize_t; ## out
                       cd_values: ptr cuint; ## out
-                      namelen: csize; name: ptr char): H5Z_filter_t {.cdecl,
+                      namelen: csize_t; name: ptr char): H5Z_filter_t {.cdecl,
       importc: "H5Pget_filter1", dynlib: libname.}
   proc H5Pget_filter_by_id1*(plist_id: hid_t; id: H5Z_filter_t; flags: ptr cuint; ## out
-                            cd_nelmts: ptr csize; ## out
+                            cd_nelmts: ptr csize_t; ## out
                             cd_values: ptr cuint; ## out
-                            namelen: csize; name: ptr char): herr_t {.cdecl,
+                            namelen: csize_t; name: ptr char): herr_t {.cdecl,
       importc: "H5Pget_filter_by_id1", dynlib: libname.}
     ## out
   proc H5Pget_version*(plist_id: hid_t; boot: ptr cuint; ## out

--- a/src/nimhdf5/wrapper/H5Rpublic.nim
+++ b/src/nimhdf5/wrapper/H5Rpublic.nim
@@ -82,7 +82,7 @@ proc H5Rget_obj_type2*(id: hid_t; ref_type: H5R_type_t; `ref`: pointer;
                       obj_type: ptr H5O_type_t): herr_t {.cdecl,
     importc: "H5Rget_obj_type2", dynlib: libname.}
 proc H5Rget_name*(loc_id: hid_t; ref_type: H5R_type_t; `ref`: pointer; name: cstring; ## out
-                 size: csize): ssize_t {.cdecl, importc: "H5Rget_name",
+                 size: csize_t): ssize_t {.cdecl, importc: "H5Rget_name",
                                       dynlib: libname.}
 ##  Symbols defined for compatibility with previous versions of the HDF5 API.
 ##

--- a/src/nimhdf5/wrapper/H5Spublic.nim
+++ b/src/nimhdf5/wrapper/H5Spublic.nim
@@ -111,7 +111,7 @@ proc H5Sset_extent_simple*(space_id: hid_t; rank: cint; dims: ptr hsize_t;
     importc: "H5Sset_extent_simple", dynlib: libname.}
 proc H5Scopy*(space_id: hid_t): hid_t {.cdecl, importc: "H5Scopy", dynlib: libname.}
 proc H5Sclose*(space_id: hid_t): herr_t {.cdecl, importc: "H5Sclose", dynlib: libname.}
-proc H5Sencode*(obj_id: hid_t; buf: pointer; nalloc: ptr csize): herr_t {.cdecl,
+proc H5Sencode*(obj_id: hid_t; buf: pointer; nalloc: ptr csize_t): herr_t {.cdecl,
     importc: "H5Sencode", dynlib: libname.}
 proc H5Sdecode*(buf: pointer): hid_t {.cdecl, importc: "H5Sdecode", dynlib: libname.}
 proc H5Sget_simple_extent_npoints*(space_id: hid_t): hssize_t {.cdecl,
@@ -141,7 +141,7 @@ when defined(NEW_HYPERSLAB_API):
       cdecl, importc: "H5Sselect_select", dynlib: libname.}
   proc H5Scombine_select*(space1_id: hid_t; op: H5S_seloper_t; space2_id: hid_t): hid_t {.
       cdecl, importc: "H5Scombine_select", dynlib: libname.}
-proc H5Sselect_elements*(space_id: hid_t; op: H5S_seloper_t; num_elem: csize;
+proc H5Sselect_elements*(space_id: hid_t; op: H5S_seloper_t; num_elem: csize_t;
                         coord: ptr hsize_t): herr_t {.cdecl,
     importc: "H5Sselect_elements", dynlib: libname.}
 proc H5Sget_simple_extent_type*(space_id: hid_t): H5S_class_t {.cdecl,

--- a/src/nimhdf5/wrapper/H5Tpublic.nim
+++ b/src/nimhdf5/wrapper/H5Tpublic.nim
@@ -226,14 +226,14 @@ type
 
 type
   hvl_t* = object
-    `len`*: csize                ##  Length of VL data (in base type units)
+    `len`*: csize_t                ##  Length of VL data (in base type units)
     p*: pointer                ##  Pointer to VL data
 
 
 ##  Variable Length String information
 
 const
-  H5T_VARIABLE* = csize.high ##  Indicate that a string is variable length (null-terminated in C, instead of fixed length)
+  H5T_VARIABLE* = csize_t.high ##  Indicate that a string is variable length (null-terminated in C, instead of fixed length)
 
 ##  Opaque information
 
@@ -245,8 +245,8 @@ const
 ##  All datatype conversion functions are...
 
 type
-  H5T_conv_t* = proc (src_id: hid_t; dst_id: hid_t; cdata: ptr H5T_cdata_t; nelmts: csize;
-                   buf_stride: csize; bkg_stride: csize; buf: pointer; bkg: pointer;
+  H5T_conv_t* = proc (src_id: hid_t; dst_id: hid_t; cdata: ptr H5T_cdata_t; nelmts: csize_t;
+                   buf_stride: csize_t; bkg_stride: csize_t; buf: pointer; bkg: pointer;
                    dset_xfer_plist: hid_t): herr_t {.cdecl.}
 
 ##  Exception handler.  If an exception like overflow happenes during conversion,
@@ -663,7 +663,7 @@ let
 
 ##  Operations defined on all datatypes
 
-proc H5Tcreate*(`type`: H5T_class_t; size: csize): hid_t {.cdecl, importc: "H5Tcreate",
+proc H5Tcreate*(`type`: H5T_class_t; size: csize_t): hid_t {.cdecl, importc: "H5Tcreate",
     dynlib: libname.}
 proc H5Tcopy*(type_id: hid_t): hid_t {.cdecl, importc: "H5Tcopy", dynlib: libname.}
 proc H5Tclose*(type_id: hid_t): herr_t {.cdecl, importc: "H5Tclose", dynlib: libname.}
@@ -681,7 +681,7 @@ proc H5Tget_create_plist*(type_id: hid_t): hid_t {.cdecl,
     importc: "H5Tget_create_plist", dynlib: libname.}
 proc H5Tcommitted*(type_id: hid_t): htri_t {.cdecl, importc: "H5Tcommitted",
     dynlib: libname.}
-proc H5Tencode*(obj_id: hid_t; buf: pointer; nalloc: ptr csize): herr_t {.cdecl,
+proc H5Tencode*(obj_id: hid_t; buf: pointer; nalloc: ptr csize_t): herr_t {.cdecl,
     importc: "H5Tencode", dynlib: libname.}
 proc H5Tdecode*(buf: pointer): hid_t {.cdecl, importc: "H5Tdecode", dynlib: libname.}
 proc H5Tflush*(type_id: hid_t): herr_t {.cdecl, importc: "H5Tflush", dynlib: libname.}
@@ -689,7 +689,7 @@ proc H5Trefresh*(type_id: hid_t): herr_t {.cdecl, importc: "H5Trefresh",
                                        dynlib: libname.}
 ##  Operations defined on compound datatypes
 
-proc H5Tinsert*(parent_id: hid_t; name: cstring; offset: csize; member_id: hid_t): herr_t {.
+proc H5Tinsert*(parent_id: hid_t; name: cstring; offset: csize_t; member_id: hid_t): herr_t {.
     cdecl, importc: "H5Tinsert", dynlib: libname.}
 proc H5Tpack*(type_id: hid_t): herr_t {.cdecl, importc: "H5Tpack", dynlib: libname.}
 ##  Operations defined on enumeration datatypes
@@ -699,7 +699,7 @@ proc H5Tenum_create*(base_id: hid_t): hid_t {.cdecl, importc: "H5Tenum_create",
 proc H5Tenum_insert*(`type`: hid_t; name: cstring; value: pointer): herr_t {.cdecl,
     importc: "H5Tenum_insert", dynlib: libname.}
 proc H5Tenum_nameof*(`type`: hid_t; value: pointer; name: cstring; ## out
-                    size: csize): herr_t {.cdecl, importc: "H5Tenum_nameof",
+                    size: csize_t): herr_t {.cdecl, importc: "H5Tenum_nameof",
                                         dynlib: libname.}
 proc H5Tenum_valueof*(`type`: hid_t; name: cstring; value: pointer): herr_t {.cdecl,
     importc: "H5Tenum_valueof", dynlib: libname.}
@@ -731,11 +731,11 @@ proc H5Tget_class*(type_id: hid_t): H5T_class_t {.cdecl, importc: "H5Tget_class"
     dynlib: libname.}
 proc H5Tdetect_class*(type_id: hid_t; cls: H5T_class_t): htri_t {.cdecl,
     importc: "H5Tdetect_class", dynlib: libname.}
-proc H5Tget_size*(type_id: hid_t): csize {.cdecl, importc: "H5Tget_size",
+proc H5Tget_size*(type_id: hid_t): csize_t {.cdecl, importc: "H5Tget_size",
                                        dynlib: libname.}
 proc H5Tget_order*(type_id: hid_t): H5T_order_t {.cdecl, importc: "H5Tget_order",
     dynlib: libname.}
-proc H5Tget_precision*(type_id: hid_t): csize {.cdecl, importc: "H5Tget_precision",
+proc H5Tget_precision*(type_id: hid_t): csize_t {.cdecl, importc: "H5Tget_precision",
     dynlib: libname.}
 proc H5Tget_offset*(type_id: hid_t): cint {.cdecl, importc: "H5Tget_offset",
                                         dynlib: libname.}
@@ -745,14 +745,14 @@ proc H5Tget_pad*(type_id: hid_t; lsb: ptr H5T_pad_t; ## out
   ## out
 proc H5Tget_sign*(type_id: hid_t): H5T_sign_t {.cdecl, importc: "H5Tget_sign",
     dynlib: libname.}
-proc H5Tget_fields*(type_id: hid_t; spos: ptr csize; ## out
-                   epos: ptr csize; ## out
-                   esize: ptr csize; ## out
-                   mpos: ptr csize; ## out
-                   msize: ptr csize): herr_t {.cdecl, importc: "H5Tget_fields",
+proc H5Tget_fields*(type_id: hid_t; spos: ptr csize_t; ## out
+                   epos: ptr csize_t; ## out
+                   esize: ptr csize_t; ## out
+                   mpos: ptr csize_t; ## out
+                   msize: ptr csize_t): herr_t {.cdecl, importc: "H5Tget_fields",
     dynlib: libname.}
   ## out
-proc H5Tget_ebias*(type_id: hid_t): csize {.cdecl, importc: "H5Tget_ebias",
+proc H5Tget_ebias*(type_id: hid_t): csize_t {.cdecl, importc: "H5Tget_ebias",
                                         dynlib: libname.}
 proc H5Tget_norm*(type_id: hid_t): H5T_norm_t {.cdecl, importc: "H5Tget_norm",
     dynlib: libname.}
@@ -766,7 +766,7 @@ proc H5Tget_member_name*(type_id: hid_t; membno: cuint): cstring {.cdecl,
     importc: "H5Tget_member_name", dynlib: libname.}
 proc H5Tget_member_index*(type_id: hid_t; name: cstring): cint {.cdecl,
     importc: "H5Tget_member_index", dynlib: libname.}
-proc H5Tget_member_offset*(type_id: hid_t; membno: cuint): csize {.cdecl,
+proc H5Tget_member_offset*(type_id: hid_t; membno: cuint): csize_t {.cdecl,
     importc: "H5Tget_member_offset", dynlib: libname.}
 proc H5Tget_member_class*(type_id: hid_t; membno: cuint): H5T_class_t {.cdecl,
     importc: "H5Tget_member_class", dynlib: libname.}
@@ -783,22 +783,22 @@ proc H5Tget_native_type*(type_id: hid_t; direction: H5T_direction_t): hid_t {.cd
     importc: "H5Tget_native_type", dynlib: libname.}
 ##  Setting property values
 
-proc H5Tset_size*(type_id: hid_t; size: csize): herr_t {.cdecl, importc: "H5Tset_size",
+proc H5Tset_size*(type_id: hid_t; size: csize_t): herr_t {.cdecl, importc: "H5Tset_size",
     dynlib: libname.}
 proc H5Tset_order*(type_id: hid_t; order: H5T_order_t): herr_t {.cdecl,
     importc: "H5Tset_order", dynlib: libname.}
-proc H5Tset_precision*(type_id: hid_t; prec: csize): herr_t {.cdecl,
+proc H5Tset_precision*(type_id: hid_t; prec: csize_t): herr_t {.cdecl,
     importc: "H5Tset_precision", dynlib: libname.}
-proc H5Tset_offset*(type_id: hid_t; offset: csize): herr_t {.cdecl,
+proc H5Tset_offset*(type_id: hid_t; offset: csize_t): herr_t {.cdecl,
     importc: "H5Tset_offset", dynlib: libname.}
 proc H5Tset_pad*(type_id: hid_t; lsb: H5T_pad_t; msb: H5T_pad_t): herr_t {.cdecl,
     importc: "H5Tset_pad", dynlib: libname.}
 proc H5Tset_sign*(type_id: hid_t; sign: H5T_sign_t): herr_t {.cdecl,
     importc: "H5Tset_sign", dynlib: libname.}
-proc H5Tset_fields*(type_id: hid_t; spos: csize; epos: csize; esize: csize; mpos: csize;
-                   msize: csize): herr_t {.cdecl, importc: "H5Tset_fields",
+proc H5Tset_fields*(type_id: hid_t; spos: csize_t; epos: csize_t; esize: csize_t; mpos: csize_t;
+                   msize: csize_t): herr_t {.cdecl, importc: "H5Tset_fields",
                                         dynlib: libname.}
-proc H5Tset_ebias*(type_id: hid_t; ebias: csize): herr_t {.cdecl,
+proc H5Tset_ebias*(type_id: hid_t; ebias: csize_t): herr_t {.cdecl,
     importc: "H5Tset_ebias", dynlib: libname.}
 proc H5Tset_norm*(type_id: hid_t; norm: H5T_norm_t): herr_t {.cdecl,
     importc: "H5Tset_norm", dynlib: libname.}
@@ -820,7 +820,7 @@ proc H5Tfind*(src_id: hid_t; dst_id: hid_t; pcdata: ptr ptr H5T_cdata_t): H5T_co
     cdecl, importc: "H5Tfind", dynlib: libname.}
 proc H5Tcompiler_conv*(src_id: hid_t; dst_id: hid_t): htri_t {.cdecl,
     importc: "H5Tcompiler_conv", dynlib: libname.}
-proc H5Tconvert*(src_id: hid_t; dst_id: hid_t; nelmts: csize; buf: pointer;
+proc H5Tconvert*(src_id: hid_t; dst_id: hid_t; nelmts: csize_t; buf: pointer;
                 background: pointer; plist_id: hid_t): herr_t {.cdecl,
     importc: "H5Tconvert", dynlib: libname.}
 ##  Symbols defined for compatibility with previous versions of the HDF5 API.

--- a/src/nimhdf5/wrapper/H5Zpublic.nim
+++ b/src/nimhdf5/wrapper/H5Zpublic.nim
@@ -153,8 +153,8 @@ type
 ##  Filter callback function definition
 
 type
-  H5Z_filter_func_t* = proc (filter: H5Z_filter_t; buf: pointer; buf_size: csize;
-                          op_data: pointer): H5Z_cb_return_t {.cdecl.}
+  H5Z_filter_func_t* = proc (filter: H5Z_filter_t; buf: pointer; buf_size: csize_t;
+                             op_data: pointer): H5Z_cb_return_t {.cdecl.}
 
 ##  Structure for filter callback property
 
@@ -231,8 +231,8 @@ type
 ##
 
 type
-  H5Z_func_t* = proc (flags: cuint; cd_nelmts: csize; cd_values: ptr cuint; nbytes: csize;
-                   buf_size: ptr csize; buf: ptr pointer): csize {.cdecl.}
+  H5Z_func_t* = proc (flags: cuint; cd_nelmts: csize_t; cd_values: ptr cuint; nbytes: csize_t;
+                      buf_size: ptr csize_t; buf: ptr pointer): csize_t {.cdecl.}
 
 ##
 ##  The filter table maps filter identification numbers to structs that

--- a/src/nimhdf5/wrapper/H5public.nim
+++ b/src/nimhdf5/wrapper/H5public.nim
@@ -150,7 +150,7 @@ template H5_VERSION_LE*(Maj, Min, Rel: untyped): untyped =
 
 ##  Define the ssize_t type if it not is defined
 
-const H5_SIZEOF_SSIZE_T = sizeof(csize)
+const H5_SIZEOF_SSIZE_T = sizeof(csize_t)
 when H5_SIZEOF_SSIZE_T == 0:
   ##  Undefine this size, we will re-define it in one of the sections below
   when H5_SIZEOF_SIZE_T == H5_SIZEOF_INT:
@@ -170,7 +170,7 @@ when H5_SIZEOF_SSIZE_T == 0:
       H5_SIZEOF_SSIZE_T* = H5_SIZEOF_LONG_LONG
 else:
   type
-    ssize_t* = csize
+    ssize_t* = csize_t
 #   else:
 ##
 ##  The sizes of file objects have their own types defined here, use a 64-bit
@@ -370,7 +370,7 @@ proc H5is_library_threadsafe*(is_ts: ptr hbool_t): herr_t {.cdecl,
     importc: "H5is_library_threadsafe", dynlib: libname.}
 proc H5free_memory*(mem: pointer): herr_t {.cdecl, importc: "H5free_memory",
                                         dynlib: libname.}
-proc H5allocate_memory*(size: csize; clear: hbool_t): pointer {.cdecl,
+proc H5allocate_memory*(size: csize_t; clear: hbool_t): pointer {.cdecl,
     importc: "H5allocate_memory", dynlib: libname.}
-proc H5resize_memory*(mem: pointer; size: csize): pointer {.cdecl,
+proc H5resize_memory*(mem: pointer; size: csize_t): pointer {.cdecl,
     importc: "H5resize_memory", dynlib: libname.}

--- a/tests/tCompound.nim
+++ b/tests/tCompound.nim
@@ -1,0 +1,52 @@
+import nimhdf5, seqmath, os
+
+const
+  File = "tests/tCompound.h5"
+  Dset = "DComp"
+  DsetTup = "DCompTup"
+
+type
+  Comp = object
+    a: float
+    b: int
+    c: float32
+
+  Tup = tuple
+    d: float
+    e: int
+    f: int
+
+proc write_dataset[T](h5f: H5File, data: seq[T], name: string) =
+  var dset = h5f.create_dataset(name, 10, T)
+  dset[dset.all] = data
+
+proc assert_dataset[T](h5f: H5File, data: seq[T], name: string) =
+  let dset = h5f[name.dset_str]
+  let readData = dset[T]
+  doAssert readData == data
+
+when isMainModule:
+  var data = newSeq[Comp](10)
+  var dataTup = newSeq[Tup](10)
+  for i in 0 ..< 10:
+    data[i] = Comp(a: i.float * 1.1, b: i, c: i.float32 / 1.111)
+    dataTup[i] = (d: i.float * 2.5, e: i * 2, f: i * 3)
+
+  var h5f = H5File(File, "rw")
+
+  h5f.write_dataset(data, Dset)
+  h5f.write_dataset(dataTup, DsetTup)
+  h5f.assert_dataset(data, Dset)
+  h5f.assert_dataset(dataTup, DsetTup)
+
+  var err = h5f.close()
+  assert err >= 0
+
+  h5f = H5File(File, "r")
+  h5f.assert_dataset(data, Dset)
+  h5f.assert_dataset(dataTup, DsetTup)
+
+  err = h5f.close()
+  assert err >= 0
+
+  removeFile(File)

--- a/tests/tStringAttributes.nim
+++ b/tests/tStringAttributes.nim
@@ -1,0 +1,42 @@
+import nimhdf5
+import sequtils
+
+import os
+import sugar
+
+const
+  File = "tests/strAttrs.h5"
+  SimpleStr = "21:19"
+  StrSeq = @["A", "funny", "sequence", "ofee", "strings", "/ea", "4vle23"]
+
+proc write_attrs(grp: H5Group) =
+  # # now write some attributes
+  grp.attrs["Simple"] = SimpleStr
+  grp.attrs["Sequence"] = StrSeq
+
+proc assert_attrs(grp: var H5Group) =
+  assert(grp.attrs["Simple", string] == SimpleStr)
+  let read = grp.attrs["Sequence", seq[string]]
+  assert(read == StrSeq)
+  assert("Simple" in grp.attrs)
+  assert("Sequence" in grp.attrs)
+
+when isMainModule:
+  var
+    h5f = H5file(File, "rw")
+
+  var grp = h5f.create_group("/")
+  grp.write_attrs()
+  grp.assert_attrs
+
+  var err = h5f.close()
+  assert(err >= 0)
+
+  h5f = H5file(File, "r")
+  grp = h5f["/".grp_str]
+  grp.assert_attrs
+
+  err = h5f.close()
+  assert(err >= 0)
+
+  removeFile(File)

--- a/tests/tattributes.nim
+++ b/tests/tattributes.nim
@@ -1,4 +1,3 @@
-
 import nimhdf5
 import ospaths
 import os


### PR DESCRIPTION
Mainly the following:

- replaces usage of `csize` by `csize_t`, since `csize` is signed (previous documentation in 2019 was saying it's `size_t` in C)
- **finally** add compound datatypes! 
- add support for `seq[string]` attributes
- some misc. convenience features. `special_type` is mostly not required anymore, but automatically determined from the given datatype. `read` procs can mostly now return variable length data automatically if the given type is `seq[T]` instead of just `T`

Full changelog:

```
- change usage of =csize= to =csize_t= in full wrapper / library. For
  most use cases this did not have any effect (=csize= was an int,
  instead of unsigned). But for =H5T_VARIABLE = csize.high= this
  caused problems, because the value was not the one expected
  (=csize_t.high=)
- add support for compound datatypes. Creating a dataset / writing and
  reading data works for any objects `T` which have fields that can be
  stored in HDF5 files currently. 
  Objects and tuples are treated the same!
- add support for =seq[string]= attributes
- reorder =datasets.nim= and clean up =[]= logic
- add =[]= accessor from a =H5Group=
- add =isVlen= helper to check if dataset is variable length
- make =special_type= usage optional when reading datasets
- fix branching in =nimToH5type= to be fully compile time
- add =H5File= to replace =H5FileObj= (latter is kept as deprecated
  typedef)
- variable lenght data is created automatically if user gives =seq[T]=
  type in =create_dataset=
- =read= can automatically read variable length data if =seq[T]=
  datatype is given
- add tests for compound data and =seq[string]= attributes
```