### PR TITLE
Fix `visit_file` for C++ backend

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.3.15
+- fix segmentation fault in =visit_file= for C++ backend
 * v0.3.14
 - fix =H5Attributes= return values for =[]= template returning
   =AnyKind=


### PR DESCRIPTION
We had an issue in `visit_file` when using the C++ backend.

The problem mentioned in a comment, which required us to cast to a `var H5FileObj` previously instead of a non mutable one is probably directly related. On the C++ backend however instead it crashed in (almost) every case. Using the underlying pointer of the `ref object` seems to work fine though.

Also cleans up old comments in the procedure and adds a sanity check.