### PR TITLE
Re-add missing import & fix `open` segfaulting for non existing datasets

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.4.1
+- adds missing import of =os.`/`= in =datasets.nim=, which got removed
+  in the refactor
+- fixes a regression in =open= for datasets in the case of a not
+  existing dataset
 * v0.4.0
 - *major* change: introduce multiple different distinct types for the
   different usages of =hid_t= in the HDF5 library. This gives us more

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -1565,7 +1565,7 @@ proc open*(h5f: H5File, dset: dset_str) =
       datatype_id.close()
     else:
       # check whether there exists a group of same name?
-      let groupOfName = h5f.isGroup(dsetOpen.name)
+      let groupOfName = h5f.isGroup(dsetName)
       if groupOfName:
         raise newException(ValueError, "Dataset with name: " & dsetName &
           " not found in file " & h5f.name & ". Instead found a group " &

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -11,24 +11,18 @@ template tryExport(body: untyped): untyped =
   when compiles(body):
     discard
 
-import options
-import tables
-import strutils
+# stdlib
+import std / [options, tables, strutils, sequtils, macros]
 tryExport:
   export nimIdentNormalize
-import sequtils
-import seqmath
-import macros
+from os import `/`
 
-import hdf5_wrapper
-import H5nimtypes
-import datatypes
-import dataspaces
-import attributes
-import filters
-import util
-import h5util
+# external nimble
+import pkg / seqmath
 
+# internal
+import hdf5_wrapper, H5nimtypes, datatypes, dataspaces,
+       attributes, filters, util, h5util
 from groups import create_group
 
 proc getDset(h5f: H5File, dsetName: string): Option[H5DataSet] =


### PR DESCRIPTION
This is a short hotfix release to fix two regressions that weren't tested before this.

An import for `os./` was removed (but is required) to access a dataset from a group using a relative path. Also fixes a regression in `datasets.open` for the case where the dataset does not exist.