### PR TITLE
add `getOrCreateGroup`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,9 +1,24 @@
+* v0.4.2
+- adds =getOrCreateGroup= helper to always get a group, either
+  returning the existing one or creating it.
+  Before version =v0.4.0= this was the default behavior for =[]= as
+  well as =create_group=.
+  As of now, =[]= raises a =KeyError= now if it does not exist (this
+  is a *breaking* change that is retroactively added to the changelog
+  of =v0.4.0=). However, =create_group= does *not* throw if the group
+  already exists. This may change in the future though.
 * v0.4.1
 - adds missing import of =os.`/`= in =datasets.nim=, which got removed
   in the refactor
 - fixes a regression in =open= for datasets in the case of a not
   existing dataset
 * v0.4.0
+- *NOTE:* At the time of release of =v0.4.0= the following *breaking*
+  change was not listed as such:
+  - =[]= for groups does *not* create a group anymore, if it does not
+    exist. Use =getOrCreateGroup= added in =v0.4.2= for that! This was
+    an unintended side effect that was overlooked, as the
+    implementation was based on =create_group=.
 - *major* change: introduce multiple different distinct types for the
   different usages of =hid_t= in the HDF5 library. This gives us more
   readability, type safety etc. We can write proper type aware =close=

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -20,6 +20,7 @@ task test, "Runs all tests":
   exec "nim c -r tests/tbasic.nim"
   exec "nim c -r tests/tdset.nim"
   exec "nim c -r tests/tread1D.nim"
+  exec "nim c -r tests/tgroups.nim"
   exec "nim c -r tests/tattributes.nim"
   exec "nim c -r tests/tvlen_array.nim"
   exec "nim c -r tests/tempty_hyperslab.nim"

--- a/src/nimhdf5/groups.nim
+++ b/src/nimhdf5/groups.nim
@@ -208,3 +208,10 @@ proc `[]`*(h5f: H5File, name: grp_str): H5Group =
   ##
   ## Throws a `KeyError` if it does not exist.
   h5f.openAndGetGroup(name.string)
+
+proc getOrCreateGroup*(h5f: H5File, name: string): H5Group =
+  ## Returns the group `name` if it exists in `h5f`. Else creates it.
+  if h5f.isGroup(name):
+    result = h5f[name.grp_str]
+  else:
+    result = h5f.create_group(name)

--- a/tests/tgroups.nim
+++ b/tests/tgroups.nim
@@ -1,4 +1,4 @@
-import nimhdf5
+import nimhdf5, os
 
 const
   File = "tests/dset.h5"

--- a/tests/tgroups.nim
+++ b/tests/tgroups.nim
@@ -1,0 +1,42 @@
+import nimhdf5
+
+const
+  File = "tests/dset.h5"
+  Grp1 = "/foo"
+  Grp2 = "/bar"
+  Grp3 = "/foo/bar"
+
+when isMainModule:
+  var h5f = H5File(File, "rw")
+
+  # manually create group
+  let grp1 = h5f.create_group(Grp1)
+  doAssert grp1.name == Grp1
+  doAssert Grp1 in h5f
+  doAssert h5f.isGroup(Grp1)
+
+  # check accessing non existant group using `[]` fails with `KeyError`
+  try:
+    let grp2 = h5f[Grp2.grp_str]
+    doAssert false
+  except KeyError:
+    doAssert true
+
+  # use `getOrCreateGroup` to create 2
+  let grp2 = h5f.getOrCreateGroup(Grp2)
+  doAssert grp2.name == Grp2
+  doAssert Grp2 in h5f
+  doAssert h5f.isGroup(Grp2)
+
+  # create 3 manually and get it using same
+  discard h5f.create_group(Grp3)
+  let grp3 = h5f.getOrCreateGroup(Grp3)
+  doAssert grp3.name == Grp3
+  doAssert Grp3 in h5f
+  doAssert h5f.isGroup(Grp3)
+
+  let err = h5f.close()
+  doAssert(err >= 0)
+
+  # clean up after ourselves
+  removeFile(File)


### PR DESCRIPTION
Adds a proc that more clearly starts a separation between getting and creating and a way to do either.

Note: `create_group` still behaves the same way. This may be changed in the future.