### PR TITLE
fixup `=destroy` hooks to clean up properly

### DIFF
--- a/README.org
+++ b/README.org
@@ -219,6 +219,89 @@ know.
   - groups
   - datasets
   - attributes
+- Single Writer Multiple Reader (SWMR). See for more info below.
+
+*** Single Writer Multiple Reader
+
+This wrapper fully supports the Single Writer Multiple Reader feature
+of the HDF5 library, but it is still in an experimental state, as I've
+never really needed it.
+
+It allows to access a single HDF5 file from multiple threads or
+processes, where one of these is a writer process and all others are
+readers. When using this feature the user does not have to worry about
+locks etc. between the different processes.
+
+**** Usage
+Open an HDF5 file in write mode and hand the =swmr= flag:
+#+begin_src nim
+# writer.nim
+import nimhdf5
+var h5f = H5open("/tmp/test.h5", "rw", swmr = true)
+# do writing stuff
+#+end_src
+and in all reader threads / processes, simply do the same, but do
+*not* hand a write:
+#+begin_src nim
+# reader.nim
+import nimhdf5
+var h5f = H5open("/tmp/test.h5", "r", swmr = true)
+#+end_src
+This *should* be all that is required.
+
+I'm not sure if the writer process should make sure to flush the file
+regularly or not. Feel free to tell me if you know. :)
+
+***** Alternative writer
+
+An alternative to the above for the writer process is to first open
+the file in write mode without ~swmr = true~ and then later put it
+into =swmr= mode via:
+#+begin_src nim
+import nimhdf5
+var h5f = H5open("/tmp/test.h5", "rw")
+# do some regular stuff
+# and then activate SWMR later
+h5f.activateSWMR()
+#+end_src
+
+*** Threadsafe HDF5 library & file locks
+
+This wrapper can also be used with a HDF5 library that was compiled
+with the =--enable-threadsafe= compilation flag.
+
+Once the library has been compiled with it, in principle the user can
+try to open a single file in write mode from multiple processes or
+threads. For safe handling in these contexts, it may be up to the user
+to lock access to the file / writing to individual datasets via some
+locking mechanism.
+In principle the threadsafe option of the library adds its own mutex
+logic, so in theory it should work without them.
+
+See these notes about the threadsafe library:
+https://support.hdfgroup.org/HDF5/doc/TechNotes/ThreadSafeLibrary.html
+
+One issue a user might encounter is that the second opening of a file
+yields an error saying that the resource is temporarily unavailable.
+In HDF5 version starting from =1.10=, file locking was added as a
+feature.
+
+This behavior is controlled via an environment variable:
+#+begin_src sh
+export HDF5_USE_FILE_LOCKING=FALSE
+#+end_src
+If set to false, file locking is *disabled*. With it multiple
+processes may open the same file.
+
+When doing this, keep in mind that each thread / process will receive
+their own =FileID=. Some HDF5 functions may either give the user
+information based on the specific file ID and others based on the
+actual file. In the cases where one can choose, it is supported via
+the =okLocal= (=ObjectKind= enum) or =fkLocal= (=FlushKind= enum).
+
+Relevant part of the documentation:
+https://docs.hdfgroup.org/hdf5/develop/_h5public_8h.html#title31
+
 
 ** Blosc support
 

--- a/src/nimhdf5.nim
+++ b/src/nimhdf5.nim
@@ -1,5 +1,4 @@
 # now import / include the relevant pieces of the library
-import nimhdf5/hdf5_wrapper
 #include nimhdf5/H5nimtypes
 import nimhdf5/H5nimtypes
 export H5nimtypes
@@ -22,7 +21,7 @@ export attributes, attribute_util
 import nimhdf5/groups
 export groups
 
-import nimhdf5/dataspaces
+# import nimhdf5/dataspaces
 # dataspaces is not exported, since the user is not supposed to have
 # to deal with dataspaces by her/himself
 #export dataspaces

--- a/src/nimhdf5/attribute_util.nim
+++ b/src/nimhdf5/attribute_util.nim
@@ -18,7 +18,7 @@ iterator attrsJson*(attrs: H5Attributes, withType = false): (string, JsonNode) =
         })
     att.close()
 
-iterator attrsJson*[T: H5FileObj | H5Group | H5DataSet](h5o: T, withType = false): (string, JsonNode) =
+iterator attrsJson*[T: H5File | H5Group | H5DataSet](h5o: T, withType = false): (string, JsonNode) =
   for key, val in attrsJson(h5o.attrs, withType = withType):
     yield (key, val)
 

--- a/src/nimhdf5/blosc_filter.nim
+++ b/src/nimhdf5/blosc_filter.nim
@@ -1,11 +1,12 @@
 # check whether blosc is available and then import and export plugin
 # else we just set the ``HasBloscSupport`` variable to false
-template canImport(x: untyped): untyped =
-  compiles:
-    import x
 
 import macros
 when defined(blosc):
+  template canImport(x: untyped): untyped =
+    compiles:
+      import x
+
   # need to have these nested, because otherwise we cannot seemingly combine
   # the two
   when canImport(blosc):

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -218,7 +218,7 @@ proc create_dataset*[T: (tuple | int | seq)](
   ##    ... some dataset object, part of the file?!
   ## throws:
   ##    ... some H5 C related errors ?!
-  if h5f.rw_type notin {H5F_ACC_EXCL, H5F_ACC_RDWR}:
+  if {akExclusive, akReadWrite} * h5f.accessFlags == {}:
     raise newException(ReadOnlyError, "Cannot create a dataset in " & $h5f.name &
       ", because the file is opened with read-only access!")
 

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -137,13 +137,13 @@ proc create_dataset_in_file(h5file_id: FileID, dset: H5DataSet): DatasetID =
   # the check can never succeed. Ok if we only check for chunksize?
   let dataspace_id = simple_dataspace(dset.shape, dset.maxshape)
   if dset.maxshape.len == 0 and dset.chunksize.len == 0:
-    result = H5Dcreate2(h5file_id.hid_t, dset.name, dset.dtype_c.hid_t, dataspace_id.hid_t,
+    result = H5Dcreate2(h5file_id.hid_t, dset.name.cstring, dset.dtype_c.hid_t, dataspace_id.hid_t,
                          H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
       .DatasetID
   else:
     # in this case we are definitely working with chunked memory of some
     # sorts, which means that the dataset creation property list is set
-    result = H5Dcreate2(h5file_id.hid_t, dset.name, dset.dtype_c.hid_t, dataspace_id.hid_t,
+    result = H5Dcreate2(h5file_id.hid_t, dset.name.cstring, dset.dtype_c.hid_t, dataspace_id.hid_t,
                          H5P_DEFAULT, dset.dcpl_id.hid_t, H5P_DEFAULT)
       .DatasetID
 
@@ -1561,7 +1561,7 @@ proc open*(h5f: H5File, dset: dset_str) =
                                                  did: dsetOpen.dataset_id),
                                         dsetOpen.name,
                                         "H5DataSet")
-      # need to close the datatype again, otherwise cause resource leak
+      # need to close the data type again, otherwise cause resource leak
       datatype_id.close()
     else:
       # check whether there exists a group of same name?

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -25,22 +25,24 @@ import hdf5_wrapper, H5nimtypes, datatypes, dataspaces,
        attributes, filters, util, h5util
 from groups import create_group
 
-proc getDset(h5f: H5File, dsetName: string): Option[H5DataSet] =
-  ## convenience proc to return the dataset with name dsetName
-  ## if it does not exist, KeyError is thrown
-  ## inputs:
-  ##    h5f: H5File = the file object from which to get the dset
-  ##    obj_name: string = name of the dset to get
-  ## outputs:
-  ##    H5DataSet = if dataset is found
-  ## throws:
-  ##    KeyError: if dataset could not be found
-  let dset_exist = hasKey(h5f.datasets, dsetName)
-  if dset_exist == false:
-    #raise newException(KeyError, "Dataset with name: " & dsetName & " not found in file " & h5f.name)
-    result = none(H5DataSet)
-  else:
-    result = some(h5f.datasets[dsetName])
+when false:
+  ## XXX: this was an idea to add a non raising API at some point. Guess I never finished that.
+  proc getDset(h5f: H5File, dsetName: string): Option[H5DataSet] =
+    ## convenience proc to return the dataset with name dsetName
+    ## if it does not exist, KeyError is thrown
+    ## inputs:
+    ##    h5f: H5File = the file object from which to get the dset
+    ##    obj_name: string = name of the dset to get
+    ## outputs:
+    ##    H5DataSet = if dataset is found
+    ## throws:
+    ##    KeyError: if dataset could not be found
+    let dset_exist = hasKey(h5f.datasets, dsetName)
+    if dset_exist == false:
+      #raise newException(KeyError, "Dataset with name: " & dsetName & " not found in file " & h5f.name)
+      result = none(H5DataSet)
+    else:
+      result = some(h5f.datasets[dsetName])
 
 proc parseShapeTuple[T: tuple](dims: T): seq[int] =
   ## parses the shape tuple handed to create_dataset

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -447,7 +447,8 @@ when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
 
   proc `=destroy`*(grp: var H5GroupObj) =
     ## Closes the group and resets all references to nil.
-    grp.file_ref = nil
+    `=destroy`(grp.file_ref) # only destroy the `ref` to the file!
+    grp.file_ref = nil # should this be destroyed?
     grp.file_id = -1.FileID
     grp.parent_id = ParentID(kind: okNone)
     grp.close()

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -495,14 +495,6 @@ when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
         when typeof(field) is string or typeof(field) is seq:
           `=destroy`(field)
 
-  #proc `=destroy`*(grp: var H5Group) =
-  #  ## Closes the group and resets all references to nil.
-  #  grp.file_ref = nil
-  #  grp.file_id = -1.FileID
-  #  grp.parent_id = ParentID(kind: okNone)
-  #  grp.close()
-  #  grp.opened = false
-
   when false:
     ## currently these are problematic, as we're allowed to just copy these IDs in Nim land,
     ## and for each copy going out of scope `=destroy` would be called. Can cause double free.

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -344,7 +344,7 @@ proc close*(dtype_id: DatatypeID) =
 
 proc close*(attr: var H5AttrObj) =
   ## closes the attribute and the corresponding dataspace
-  if attr.opened:
+  if attr.opened and attr.attr_id.hid_t.isObjectOpen:
     var err = H5Aclose(attr.attr_id.hid_t)
     if err < 0:
       raise newException(HDF5LibraryError, "Error closing attribute with id " &

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -1,8 +1,8 @@
 # stdlib
-import std / [tables, strutils, sequtils, options]
+import std / [tables, strutils]
 from os import fileExists
 # internal
-import hdf5_wrapper, H5nimtypes, datatypes, dataspaces, attributes, h5util, util
+import hdf5_wrapper, H5nimtypes, datatypes, h5util, util
 from datasets import `[]`
 from groups import create_group, `[]`
 

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -222,16 +222,21 @@ proc close*(h5f: H5File): herr_t =
   # now close all remaining objects, which we might have missed above
   # TODO: it seems we're missing some attributes. The rest is typically closed
   # find out where we miss them!
-  for t in ObjectKind:
-    if t in {okAll, okNone}: continue
-    let objsStillOpen = h5f.getOpenObjectIds(t)
-    if objsStillOpen.len > 0:
-      for id in objsStillOpen:
-        # only close non files (file will be closed below)
-        case t
-        of okFile: discard
-        else:
-          result = close(id, t)
+  when false:
+    ## NOTE: this code is problematic: If one file is opened from two threads,
+    ## the H5 call will also return the open ids of the other instance. So this
+    ## code leads to closing those. Once the other file will be closed, the `opened`
+    ## field is out of sync and it leads to H5 errors (and then an exception).
+    for t in ObjectKind:
+      if t in {okAll, okNone}: continue
+      let objsStillOpen = h5f.getOpenObjectIds(t)
+      if objsStillOpen.len > 0:
+        for id in objsStillOpen:
+          # only close non files (file will be closed below)
+          case t
+          of okFile: discard
+          else:
+            result = close(id, t)
 
   withDebug:
     let objsYet = h5f.getOpenObjectIds(okAll)

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -244,11 +244,12 @@ proc close*(h5f: H5File): herr_t =
     # should be zero now
     echo "Still open objects are ", objsYet
 
-  # flush the file
-  result = H5Fflush(h5f.file_id.hid_t, H5F_SCOPE_GLOBAL)
+  if h5f.isObjectOpen: # close file only if still open
+    # flush the file
+    result = H5Fflush(h5f.file_id.hid_t, H5F_SCOPE_GLOBAL)
 
-  # close the remaining attributes
-  result = H5Fclose(h5f.file_id.hid_t)
+    # close the remaining attributes
+    result = H5Fclose(h5f.file_id.hid_t)
 
 template withH5*(h5file, rw_type: string, actions: untyped) =
   ## template to work with a H5 file, taking care of opening

--- a/src/nimhdf5/groups.nim
+++ b/src/nimhdf5/groups.nim
@@ -63,7 +63,7 @@ proc openGroup*(h5f: H5File, group: string): GroupID =
     withDebug:
       debugEcho "Group exists H5Gopen2() returned id ", result
   else:
-    raise newException(KeyError, "Group with name `" & $group.string & "` does not " &
+    raise newException(KeyError, "Group with name `" & $group & "` does not " &
       "exist in file `" & $h5f.name & ".")
 
 proc createGroupImpl*(h5f: H5File, group: string): GroupID =

--- a/src/nimhdf5/groups.nim
+++ b/src/nimhdf5/groups.nim
@@ -2,52 +2,54 @@ import std / [tables, options, strutils]
 
 import hdf5_wrapper, H5nimtypes, datatypes, attributes, h5util, util
 
-proc getGroup(h5f: H5File, grp_name: string): Option[H5Group] =
-  ## convenience proc to return the group with name grp_name
-  ## if it does not exist, KeyError is thrown
-  ## inputs:
-  ##    h5f: H5File = the file object from which to get the group
-  ##    obj_name: string = name of the group to get
-  ## outputs:
-  ##    H5Group = if group is found
-  ## throws:
-  ##    KeyError: if group could not be found
-  let grp_exist = hasKey(h5f.datasets, grp_name)
-  if grp_exist == false:
-    #raise newException(KeyError, "Dataset with name: " & grp_name & " not found in file " & h5f.name)
-    result = none(H5Group)
-  else:
-    result = some(h5f.groups[grp_name])
-
-proc create_group*[T](h5f: T, group_name: string): H5Group
-proc get(h5f: H5File, group_in: grp_str): H5Group =
-  ## convenience proc to return the group with name group_name
-  ## if it does not exist, KeyError is thrown
-  ## inputs:
-  ##    h5f: H5File = the file object from which to get the dset
-  ##    obj_name: string = name of the dset to get
-  ## outputs:
-  ##    H5Group = if group is found
-  ## throws:
-  ##    KeyError: if group could not be found
-  let
-    group_name = string(group_in)
-    group_open = h5f.isOpen(group_in)
-  if not group_open:
-    # if group not known (potentially the case if:
-    # - no call to visit_file (read all grps / dsets)
-    # - not created individually directly / indirectly
-    # check for existence in file
-    let exists = existsInFile(h5f.file_id, group_name)
-    if exists > hid_t(0):
-      # get group from file
-      result = h5f.create_group(group_name)
+when false:
+  ## XXX: this was an attempt to add a non raising API, but I never finished it...
+  proc getGroup(h5f: H5File, grp_name: string): Option[H5Group] =
+    ## convenience proc to return the group with name grp_name
+    ## if it does not exist, KeyError is thrown
+    ## inputs:
+    ##    h5f: H5File = the file object from which to get the group
+    ##    obj_name: string = name of the group to get
+    ## outputs:
+    ##    H5Group = if group is found
+    ## throws:
+    ##    KeyError: if group could not be found
+    let grp_exist = hasKey(h5f.datasets, grp_name)
+    if grp_exist == false:
+      #raise newException(KeyError, "Dataset with name: " & grp_name & " not found in file " & h5f.name)
+      result = none(H5Group)
     else:
-      # does not exists, raise exception
-      raise newException(KeyError, "Group with name: " & group_name & " not found in file " & h5f.name)
-  else:
-    result = h5f.groups[group_name]
-    doAssert result.opened
+      result = some(h5f.groups[grp_name])
+
+  proc create_group*[T](h5f: T, group_name: string): H5Group
+  proc get(h5f: H5File, group_in: grp_str): H5Group =
+    ## convenience proc to return the group with name group_name
+    ## if it does not exist, KeyError is thrown
+    ## inputs:
+    ##    h5f: H5File = the file object from which to get the dset
+    ##    obj_name: string = name of the dset to get
+    ## outputs:
+    ##    H5Group = if group is found
+    ## throws:
+    ##    KeyError: if group could not be found
+    let
+      group_name = string(group_in)
+      group_open = h5f.isOpen(group_in)
+    if not group_open:
+      # if group not known (potentially the case if:
+      # - no call to visit_file (read all grps / dsets)
+      # - not created individually directly / indirectly
+      # check for existence in file
+      let exists = existsInFile(h5f.file_id, group_name)
+      if exists > hid_t(0):
+        # get group from file
+        result = h5f.create_group(group_name)
+      else:
+        # does not exists, raise exception
+        raise newException(KeyError, "Group with name: " & group_name & " not found in file " & h5f.name)
+    else:
+      result = h5f.groups[group_name]
+      doAssert result.opened
 
 proc openGroup*(h5f: H5File, group: string): GroupID =
   ## Opens the given `group` in the `h5f` file. Throws `KeyError` if the given
@@ -83,12 +85,14 @@ proc createGroupImpl*(h5f: H5File, group: string): GroupID =
       "`createGroupFromParent` trying to create group via `H5Gcreate2`!")
 
 
-proc updateGroupInfo(h5f: H5File, grp: var H5Group) =
-  ## Updates all information of the given group `grp` by calling into the HDF5 library.
-  ##
-  ## Note: this procedure raises, if the given group does not yet exist in the
-  ## file. Or should it not raise?
-  # essentially the body of the below proc
+when false:
+  ## XXX: this is still not properly implemented...
+  proc updateGroupInfo(h5f: H5File, grp: var H5Group) =
+    ## Updates all information of the given group `grp` by calling into the HDF5 library.
+    ##
+    ## Note: this procedure raises, if the given group does not yet exist in the
+    ## file. Or should it not raise?
+    # essentially the body of the below proc
 
 proc createGroupFromParent[T: H5Group | H5File](h5o: T, group_name: string): H5Group =
   ## procedure to create a group within a H5F
@@ -198,7 +202,7 @@ proc create_group*[T](h5f: T, group_name: string): H5Group =
     # whether such a group already exists
     # in the HDF5 file and h5f is simply not aware of it yet
     if isInH5Root(group_path) == false:
-      let parent = create_group(h5f, getParent(group_path))
+      discard create_group(h5f, getParent(group_path))
       result = createGroupFromParent(h5f, group_path)
     else:
       result = createGroupFromParent(h5f, group_path)

--- a/src/nimhdf5/h5_iterators.nim
+++ b/src/nimhdf5/h5_iterators.nim
@@ -1,6 +1,6 @@
 import std / [strutils, tables]
 
-import datatypes, h5util, util, groups, datasets, pretty_printing
+import datatypes, h5util, util, groups, datasets
 
 iterator items*(h5f: H5File, start_path = "/", depth = -1): H5Group =
   ## iterator, which returns a non mutable group objects starting from `start_path` in the

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -207,7 +207,7 @@ proc existsInFile*(h5id: FileID, name: string): hid_t =
       continue
     # need to convert result of H5Lexists to hid_t, because return type is
     # `htri_t` from the H5 wrapper
-    result = H5Lexists(h5id.hid_t, toCheck, H5P_DEFAULT).hid_t
+    result = H5Lexists(h5id.hid_t, toCheck.cstring, H5P_DEFAULT).hid_t
     if result == 0:
       # does not exist, so break, even if we're not at the deepest level
       break

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -325,6 +325,12 @@ proc getOpenObjectIds*(h5f: H5File, kind: ObjectKind,
                        bufSize = 1000): seq[hid_t] =
   result = h5f.file_id.getOpenObjectIds(kind, bufsize)
 
+proc isValidID*(h5id: hid_t): bool {.inline.} =
+  ## This is essentially just an alias to `isObjectOpen` as that is the original use
+  ## case of the underlying procedure. In some cases it may be logical to check for
+  ## valid-ness of an ID instead of whether an object is open (for clarity in code)
+  result = h5id.isObjectOpen
+
 proc getRefcount*(h5id: hid_t): int {.inline.} =
   if h5id.isObjectOpen:
     let err = H5Iget_ref(h5id)
@@ -383,14 +389,15 @@ when false:
   ## this is also super helpful
   proc getName*(h5id: hid_t): string =
     ## Returns the name associated with the given ID.
+    ##
+    ## NOTE: this procedure may only be called, if the given ID is still valid!
+    ## Needs to be wrapped in something
     var size = H5Iget_name(h5id, nil, 0)
     result = newString(size) # nim strings are already zero terminated
     let err = H5Iget_name(h5id, result, size + 1) # +1 for zero termination
     if err < 0:
       raise newException(HDF5LibraryError, "Call to `H5Iget_name` failed trying to determine " &
         "name of object with ID: " & $h5id)
-
-
 
 proc contains*(h5f: H5File, name: string): bool =
   ## Checks if the given `name` is contained in the H5 file.

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -381,11 +381,14 @@ proc getFileID*[T: H5Dataset | H5DatasetObj | H5Group | H5GroupObj | H5Attr | H5
     let id = h5o.getH5ID.to_hid_t
   result = id.getFileID()
 
-when false:
-  ## XXX: add an enum to map the types associated with identifiers.
-  proc getH5Type*(h5id: hid_t): SomeType =
-    result = H5Iget_type(h5id)
+proc getType*(h5id: hid_t): H5I_type_t =
+  ## Returns the type associated with an arbitrary H5 identifier.
+  ##
+  ## Might return `H5I_BADID` (field of the enum) if the ID does not match
+  ## any known identifier.
+  result = H5Iget_type(h5id)
 
+when false:
   ## this is also super helpful
   proc getName*(h5id: hid_t): string =
     ## Returns the name associated with the given ID.

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -275,6 +275,14 @@ proc getObjectTypeByName*(h5id: FileID | GroupID | DatasetID, name: string): H5O
   else:
     raise newException(HDF5LibraryError, "Call to HDF5 library failed in `getObjectTypeByName`")
 
+proc getObjectInfo*(h5id: FileID | GroupID | DatasetID): H5O_info_t =
+  ## Returns the object info for a single object in the H5 file
+  let err = H5Oget_info(h5id.hid_t, addr result)
+  if err >= 0:
+    echo result
+  else:
+    raise newException(HDF5LibraryError, "Call to HDF5 library failed in `getObjectInfo`")
+
 proc getObjectTypeByName*(h5id: ParentID, name: string): H5O_type_t =
   case h5id.kind
   of okFile: result = getObjectTypeByName(h5id.fid, name)

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -6,16 +6,11 @@
 # it is not (yet) warranted to have an individual file for, e.g.
 # procs related to general H5 objects.
 
-import strutils, strformat
-import ospaths
-import options
-import tables
+import std / [strutils, strformat, options, tables, sequtils]
+from os import `/`
 
 # nimhdf5 related libraries
-import hdf5_wrapper
-import H5nimtypes
-import util
-import datatypes
+import hdf5_wrapper, H5nimtypes, util, datatypes
 
 proc contains*(h5f: H5File, name: string): bool
 proc contains*(grp: H5Group, name: string): bool
@@ -310,32 +305,27 @@ proc printOpenObjects*(h5f: H5File) =
   echo "\t\t types open: ", typesOpen
   echo "\t\t attrs open: ", attrsOpen
 
-when false:
-  proc getOpenObjectIds*(h5f: H5File, kind: ObjectKind,
-                         bufSize = 1000): seq[hid_t] =
-    ## Return all IDs of objects of `kind` that are still open in the file.
-    ##
-    ## This will fail if there are more than `bufSize` elements open!
-    ##
-    ## Returns a sequence of `hid_t` as we haven't checked what object types they are
-    ## nor can we return a sequence of different types.
-    let h5Kind = parseObjectKindToH5(kind)
-    # create buffer size of `bufSize`. Should be plenty for open ids
-    # if not, something is wrong anyways (I'd assume?)
-    var objList = newSeq[hid_t](bufSize)
-    let objsOpen = H5Fget_obj_ids(h5f.file_id.hid_t,
-                                  h5Kind.cuint, bufSize.csize_t, addr objList[0])
-    result = objList.filterIt(it > 0)
+proc getOpenObjectIds*(h5id: FileID | GroupID, kind: ObjectKind,
+                       bufSize = 1000): seq[hid_t] =
+  ## Return all IDs of objects of `kind` that are still open in the file.
+  ##
+  ## This will fail if there are more than `bufSize` elements open!
+  ##
+  ## Returns a sequence of `hid_t` as we haven't checked what object types they are
+  ## nor can we return a sequence of different types.
+  let h5Kind = parseObjectKindToH5(kind)
+  # create buffer size of `bufSize`. Should be plenty for open ids
+  # if not, something is wrong anyways (I'd assume?)
+  var objList = newSeq[hid_t](bufSize)
+  let objsOpen = H5Fget_obj_ids(h5id.hid_t,
+                                h5Kind.cuint, bufSize.csize_t, addr objList[0])
+  result = objList.filterIt(it > 0)
 
-  proc isObjectOpen*[T: H5File | H5Group | H5Dataset](h5f: H5File, h5oid: T): bool =
-    when T is H5File:
-      let ids = h5f.getOpenObjectIds(okFile)
-    elif T is H5Group:
-      let ids = h5f.getOpenObjectIds(okGroup)
-    elif T is H5Dataset:
-      let ids = h5f.getOpenObjectIds(okDataset)
-    for id in ids:
-      if id == h5oid: return true # id in returned list, so is open
+proc getOpenObjectIds*(h5f: H5File, kind: ObjectKind,
+                       bufSize = 1000): seq[hid_t] =
+  result = h5f.file_id.getOpenObjectIds(kind, bufsize)
+
+when false:
 
 proc contains*(h5f: H5File, name: string): bool =
   ## Checks if the given `name` is contained in the H5 file.

--- a/src/nimhdf5/hdf5_wrapper.nim
+++ b/src/nimhdf5/hdf5_wrapper.nim
@@ -26,7 +26,7 @@
    in the Nim progams as function arguments without getting any weird errors.
 ]#
 
-include
+import
   nimhdf5/wrapper/H5public, nimhdf5/wrapper/H5Apublic,        ##  Attributes
   nimhdf5/wrapper/H5ACpublic,                 ##  Metadata cache
   nimhdf5/wrapper/H5Dpublic,                  ##  Datasets
@@ -44,12 +44,31 @@ include
   nimhdf5/wrapper/H5Spublic,                  ##  Dataspaces
   nimhdf5/wrapper/H5Tpublic,                  ##  Datatypes
   nimhdf5/wrapper/H5Zpublic
+export
+  H5public, H5Apublic,
+  H5ACpublic,
+  H5Dpublic,
+  H5Epublic,
+  H5Fpublic,
+  H5FDpublic,
+  H5Gpublic,
+  H5Ipublic,
+  H5Lpublic,
+  H5MMpublic,
+  H5Opublic,
+  H5Ppublic,
+  H5PLpublic,
+  H5Rpublic,
+  H5Spublic,
+  H5Tpublic,
+  H5Zpublic
+
 
 
 ##  Data filters
 ##  Predefined file drivers
 
-include
+import
   nimhdf5/wrapper/H5FDcore,                   ##  Files stored entirely in memory
   nimhdf5/wrapper/H5FDdirect,                 ##  Linux direct I/O
   nimhdf5/wrapper/H5FDfamily,                 ##  File families
@@ -58,6 +77,15 @@ include
   nimhdf5/wrapper/H5FDmulti,                  ##  Usage-partitioned file family
   nimhdf5/wrapper/H5FDsec2,                   ##  POSIX unbuffered file I/O
   nimhdf5/wrapper/H5FDstdio
+export
+  H5FDcore,                   ##  Files stored entirely in memory
+  H5FDdirect,                 ##  Linux direct I/O
+  H5FDfamily,                 ##  File families
+  H5FDlog,                    ##  sec2 driver with I/O logging (for debugging)
+  H5FDmpi,                    ##  MPI-based file drivers
+  H5FDmulti,                  ##  Usage-partitioned file family
+  H5FDsec2,                   ##  POSIX unbuffered file I/O
+  H5FDstdio
 
 when defined(H5_HAVE_WINDOWS): ##  Standard C buffered I/O
   import

--- a/src/nimhdf5/pretty_printing.nim
+++ b/src/nimhdf5/pretty_printing.nim
@@ -1,5 +1,5 @@
 import std / [strutils, strformat, tables]
-import datatypes, H5nimtypes, attribute_util, json
+import datatypes, H5nimtypes, attribute_util, json, util
 
 proc pretty*(att: H5Attr, indent = 0, full = false): string =
   result = repeat(' ', indent) & "{\n"
@@ -100,11 +100,21 @@ proc `$`*(grp: H5Group): string =
   ## to string conversion for a `H5Group` for pretty printing
   result = pretty(grp, full = false)
 
+proc `$`*[T: AccessKind | ObjectKind](s: set[T]): string =
+  result = "{"
+  var idx = 0
+  for el in iterateEnumSet(s):
+    if idx < s.card:
+      result.add $el & ", "
+    else:
+      result.add $el
+  result.add "}"
+
 proc pretty*(h5f: H5File, indent = 2, full = false): string =
   result = repeat(' ', indent) & "{\n"
   let fieldInd = repeat(' ', indent + 2)
   result.add &"{fieldInd}name: {h5f.name},\n"
-  result.add &"{fieldInd}rw_type: {h5f.rw_type},\n"
+  result.add &"{fieldInd}accessFlags: {h5f.accessFlags},\n"
   result.add &"{fieldInd}visited: {h5f.visited}"
   if full:
     result.add &",\n{fieldInd}nfile_id: {h5f.file_id.hid_t},\n"

--- a/src/nimhdf5/wrapper/H5ACpublic.nim
+++ b/src/nimhdf5/wrapper/H5ACpublic.nim
@@ -28,7 +28,7 @@
 {.deadCodeElim: on.}
 
 import
-  H5public, H5Cpublic, ../H5nimtypes, ../h5libname
+  H5Cpublic, ../H5nimtypes
 
 
 

--- a/src/nimhdf5/wrapper/H5Apublic.nim
+++ b/src/nimhdf5/wrapper/H5Apublic.nim
@@ -20,7 +20,6 @@
 
 import
   H5public,
-  H5Ipublic,                  ##  IDs
   H5Opublic,                  ##  Object Headers
   H5Tpublic,
   ../H5nimtypes, ../h5libname

--- a/src/nimhdf5/wrapper/H5Cpublic.nim
+++ b/src/nimhdf5/wrapper/H5Cpublic.nim
@@ -28,9 +28,6 @@
 
 ##  Public headers needed by this file
 
-import
-  H5public, ../h5libname
-
 type
   H5C_cache_incr_mode* {.size: sizeof(cint).} = enum
     H5C_incr_off, H5C_incr_threshold

--- a/src/nimhdf5/wrapper/H5Dpublic.nim
+++ b/src/nimhdf5/wrapper/H5Dpublic.nim
@@ -20,7 +20,7 @@
 ##  Public headers needed by this file
 
 import
-  H5public, H5Ipublic, ../H5nimtypes, ../h5libname
+  H5public, ../H5nimtypes, ../h5libname
 
 
 

--- a/src/nimhdf5/wrapper/H5Epublic.nim
+++ b/src/nimhdf5/wrapper/H5Epublic.nim
@@ -19,7 +19,7 @@
 ##  Public headers needed by this file
 
 import
-  H5public, H5Ipublic, ../H5nimtypes, ../h5libname
+  ../H5nimtypes, ../h5libname
 
 # before we can import any of the variables, from the already shared library
 # we need to make sure that they are defined. The library needs to be

--- a/src/nimhdf5/wrapper/H5FDdirect.nim
+++ b/src/nimhdf5/wrapper/H5FDdirect.nim
@@ -12,7 +12,6 @@
 ##  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 {.deadCodeElim: on.}
-import ../h5libname
 ##
 ##  Programmer:  Raymond Lu <slu@hdfgroup.uiuc.edu>
 ##               Wednesday, 20 September 2006

--- a/src/nimhdf5/wrapper/H5FDmpi.nim
+++ b/src/nimhdf5/wrapper/H5FDmpi.nim
@@ -13,12 +13,12 @@
 
 {.deadCodeElim: on.}
 
-## 
+##
 ##  Programmer:  Quincey Koziol <koziol@ncsa.uiuc.edu>
 ##               Friday, January 30, 2004
-## 
+##
 ##  Purpose:	The public header file for common items for all MPI VFL drivers
-## 
+##
 
 ## **** Macros for One linked collective IO case. ****
 ##  The default value to do one linked collective IO for all chunks.
@@ -33,7 +33,7 @@ const
 ##  The default value of the threshold to do collective IO for this chunk.
 ##    If the average percentage of processes per chunk is greater than the default value,
 ##    collective IO is done for this chunk.
-## 
+##
 
 const
   H5D_MULTI_CHUNK_IO_COL_THRESHOLD* = 60
@@ -62,8 +62,5 @@ type
 
 
 ##  Include all the MPI VFL headers
-
-import
-  H5FDmpio
 
 ##  MPI I/O file driver

--- a/src/nimhdf5/wrapper/H5FDmpio.nim
+++ b/src/nimhdf5/wrapper/H5FDmpio.nim
@@ -13,9 +13,6 @@
 
 {.deadCodeElim: on.}
 
-import ../h5libname
-
-
 ##
 ##  Programmer:  Robb Matzke <matzke@llnl.gov>
 ##               Monday, August  2, 1999

--- a/src/nimhdf5/wrapper/H5FDpublic.nim
+++ b/src/nimhdf5/wrapper/H5FDpublic.nim
@@ -333,8 +333,8 @@ type
     terminate*: proc (): herr_t {.cdecl.}
     sb_size*: proc (file: ptr H5FD_t_prot): hsize_t {.cdecl.}
     sb_encode*: proc (file: ptr H5FD_t_prot; name: cstring; ## out
-                    p: ptr cuchar): herr_t {.cdecl.} ## out
-    sb_decode*: proc (f: ptr H5FD_t_prot; name: cstring; p: ptr cuchar): herr_t {.cdecl.}
+                      p: ptr char): herr_t {.cdecl.} ## out
+    sb_decode*: proc (f: ptr H5FD_t_prot; name: cstring; p: ptr char): herr_t {.cdecl.}
     fapl_size*: csize_t
     fapl_get*: proc (file: ptr H5FD_t_prot): pointer {.cdecl.}
     fapl_copy*: proc (fapl: pointer): pointer {.cdecl.}

--- a/src/nimhdf5/wrapper/H5FDstdio.nim
+++ b/src/nimhdf5/wrapper/H5FDstdio.nim
@@ -20,7 +20,6 @@
 {.deadCodeElim: on.}
 
 import
-  H5Ipublic,
   ../H5nimtypes, ../h5libname
 
 

--- a/src/nimhdf5/wrapper/H5Fpublic.nim
+++ b/src/nimhdf5/wrapper/H5Fpublic.nim
@@ -84,14 +84,14 @@ const
 ##  Flags for H5Fget_obj_count() & H5Fget_obj_ids() calls
 
 const
-  H5F_OBJ_FILE* = (0x00000001)  ##  File objects
-  H5F_OBJ_DATASET* = (0x00000002) ##  Dataset objects
-  H5F_OBJ_GROUP* = (0x00000004) ##  Group objects
-  H5F_OBJ_DATATYPE* = (0x00000008) ##  Named datatype objects
-  H5F_OBJ_ATTR* = (0x00000010)  ##  Attribute objects
+  H5F_OBJ_FILE* = cuint(0x00000001)  ##  File objects
+  H5F_OBJ_DATASET* = cuint(0x00000002) ##  Dataset objects
+  H5F_OBJ_GROUP* = cuint(0x00000004) ##  Group objects
+  H5F_OBJ_DATATYPE* = cuint(0x00000008) ##  Named datatype objects
+  H5F_OBJ_ATTR* = cuint(0x00000010)  ##  Attribute objects
   H5F_OBJ_ALL* = (H5F_OBJ_FILE or H5F_OBJ_DATASET or H5F_OBJ_GROUP or
       H5F_OBJ_DATATYPE or H5F_OBJ_ATTR)
-  H5F_OBJ_LOCAL* = (0x00000020) ##  Restrict search to objects opened through current file ID
+  H5F_OBJ_LOCAL* = cuint(0x00000020) ##  Restrict search to objects opened through current file ID
 
 ##  (as opposed to objects opened through any file ID accessing this file)
 

--- a/src/nimhdf5/wrapper/H5Fpublic.nim
+++ b/src/nimhdf5/wrapper/H5Fpublic.nim
@@ -20,7 +20,7 @@
 ##  Public header files needed by this file
 
 import
-  H5public, H5ACpublic, H5Ipublic, ../H5nimtypes, ../h5libname
+  H5public, H5ACpublic, ../H5nimtypes, ../h5libname
 
 ##  When this header is included from a private header, don't make calls to H5check()
 

--- a/src/nimhdf5/wrapper/H5Fpublic.nim
+++ b/src/nimhdf5/wrapper/H5Fpublic.nim
@@ -55,13 +55,15 @@ import
 ##  /\* NOTE: 0x0008u was H5F_ACC_DEBUG, now deprecated *\/
 ##  #define H5F_ACC_CREAT	(H5CHECK H5OPEN 0x0010u)	/\*create non-existing files  *\/
 ##  #define H5F_ACC_SWMR_WRITE	(H5CHECK 0x0020u) /\*indicate that this file is
+
 const
   H5F_ACC_RDONLY*     = cuint(0x0000)
   H5F_ACC_RDWR*       = cuint(0x0001)
   H5F_ACC_TRUNC*      = cuint(0x0002)
-  H5F_ACC_EXCL*        = cuint(0x0004)
+  H5F_ACC_EXCL*       = cuint(0x0004)
   H5F_ACC_CREAT*      = cuint(0x0010)
   H5F_ACC_SWMR_WRITE* = cuint(0x0020)
+  H5F_ACC_SWMR_READ*  = cuint(0x0040)
 ##                                                   * open for writing in a
 ##                                                   * single-writer/multi-reader (SWMR)
 ##                                                   * scenario.  Note that the

--- a/src/nimhdf5/wrapper/H5Gpublic.nim
+++ b/src/nimhdf5/wrapper/H5Gpublic.nim
@@ -32,7 +32,6 @@ import
   H5public,                   ##  Generic Functions
   H5Lpublic,                  ##  Links
   H5Opublic,                  ##  Object headers
-  H5Tpublic,
   ../H5nimtypes, ../h5libname
 
 

--- a/src/nimhdf5/wrapper/H5Lpublic.nim
+++ b/src/nimhdf5/wrapper/H5Lpublic.nim
@@ -28,7 +28,6 @@
 
 import
   H5public,                   ##  Generic Functions
-  H5Ipublic,                  ##  IDs
   H5Tpublic,
   ../H5nimtypes, ../h5libname
 
@@ -84,7 +83,7 @@ const
 ##  Information struct for link (for H5Lget_info/H5Lget_info_by_idx)
 
 type
-  INNER_C_UNION_3734014316* = object {.union.}
+  INNER_C_UNION_3734014316* {.union.} = object
     address*: haddr_t          ##  Address hard link points to
     val_size*: csize_t           ##  Size of a soft link or UD link value
 

--- a/src/nimhdf5/wrapper/H5MMpublic.nim
+++ b/src/nimhdf5/wrapper/H5MMpublic.nim
@@ -27,11 +27,6 @@
 ## -------------------------------------------------------------------------
 ##
 
-##  Public headers needed by this file
-
-import
-  H5public, ../h5libname
-
 ##  These typedefs are currently used for VL datatype allocation/freeing
 
 type

--- a/src/nimhdf5/wrapper/H5Opublic.nim
+++ b/src/nimhdf5/wrapper/H5Opublic.nim
@@ -29,8 +29,6 @@
 
 import
   H5public,                   ##  Generic Functions
-  H5Ipublic,                  ##  IDs
-  H5Lpublic,
   ../H5nimtypes, ../h5libname
 
 

--- a/src/nimhdf5/wrapper/H5Ppublic.nim
+++ b/src/nimhdf5/wrapper/H5Ppublic.nim
@@ -21,7 +21,7 @@
 ##  Public headers needed by this file
 
 import
-  H5public, H5ACpublic, H5Dpublic, H5Fpublic, H5FDpublic, H5Ipublic, H5Lpublic,
+  H5ACpublic, H5Dpublic, H5Fpublic, H5FDpublic, H5Lpublic,
   H5Opublic, H5MMpublic, H5Tpublic, H5Zpublic, ../H5nimtypes, ../h5libname
 
 

--- a/src/nimhdf5/wrapper/H5Rpublic.nim
+++ b/src/nimhdf5/wrapper/H5Rpublic.nim
@@ -22,7 +22,7 @@
 import
   H5public,
   H5Gpublic,
-  H5Ipublic,
+  H5Opublic,
   ../H5nimtypes, ../h5libname
 
 
@@ -63,7 +63,7 @@ const
 ##  Dataset Region reference structure for user's code
 
 type
-  hdset_reg_ref_t* = array[H5R_DSET_REG_REF_BUF_SIZE, cuchar]
+  hdset_reg_ref_t* = array[H5R_DSET_REG_REF_BUF_SIZE, char]
 
 ##  Buffer to store heap ID and index
 ##  Needs to be large enough to store largest haddr_t in a worst case machine (ie. 8 bytes currently) plus an int

--- a/src/nimhdf5/wrapper/H5Spublic.nim
+++ b/src/nimhdf5/wrapper/H5Spublic.nim
@@ -20,8 +20,7 @@
 ##  Public headers needed by this file
 
 import
-  H5public, H5Ipublic, ../H5nimtypes, ../h5libname
-
+  ../H5nimtypes, ../h5libname
 
 ##  Define atomic datatypes
 

--- a/src/nimhdf5/wrapper/H5Tpublic.nim
+++ b/src/nimhdf5/wrapper/H5Tpublic.nim
@@ -19,7 +19,7 @@
 ##  Public headers needed by this file
 
 import
-  H5public, H5Ipublic, ../H5nimtypes, ../h5libname
+  ../H5nimtypes, ../h5libname
 
 
 
@@ -27,7 +27,6 @@ import
 # we need to make sure that they are defined. The library needs to be
 # initialized. Thus we include
 include H5niminitialize
-
 
 template HOFFSET*(S, M: untyped): untyped =
   (offsetof(S, M))

--- a/src/nimhdf5/wrapper/H5Zpublic.nim
+++ b/src/nimhdf5/wrapper/H5Zpublic.nim
@@ -20,7 +20,7 @@
 ##  Public headers needed by this file
 
 import
-  H5public, ../H5nimtypes, ../h5libname
+  ../H5nimtypes, ../h5libname
 
 
 ##

--- a/src/nimhdf5/wrapper/H5public.nim
+++ b/src/nimhdf5/wrapper/H5public.nim
@@ -197,9 +197,9 @@ else:
 ##  File addresses have their own types.
 ##
 
-const H5_SIZEOF_INT = sizeof(cint)
-const H5_SIZEOF_LONG = sizeof(clong)
-const H5_SIZEOF_LONG_LONG = sizeof(clonglong)
+const H5_SIZEOF_INT* = sizeof(cint)
+const H5_SIZEOF_LONG* = sizeof(clong)
+const H5_SIZEOF_LONG_LONG* = sizeof(clonglong)
 
 when H5_SIZEOF_INT >= 8:
   type
@@ -246,8 +246,8 @@ const
 ##  defined in Posix.1g, otherwise it is defined here.
 ##
 
-const H5_SIZEOF_UINT32_T = sizeof(cuint)
-const H5_SIZEOF_SHORT = sizeof(cshort)
+const H5_SIZEOF_UINT32_T* = sizeof(cuint)
+const H5_SIZEOF_SHORT* = sizeof(cshort)
 when H5_SIZEOF_UINT32_T >= 4:
   # this is empty in the original H5 code.
   type

--- a/tests/t17.nim
+++ b/tests/t17.nim
@@ -28,7 +28,7 @@ template check(actions: untyped) =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
 
   var dset1 = h5f.create_dataset(DsetName2, (9, 9), int,
                                  chunksize = @[27, 27],

--- a/tests/tCompound.nim
+++ b/tests/tCompound.nim
@@ -32,7 +32,7 @@ when isMainModule:
     data[i] = Comp(a: i.float * 1.1, b: i, c: i.float32 / 1.111)
     dataTup[i] = (d: i.float * 2.5, e: i * 2, f: i * 3)
 
-  var h5f = H5File(File, "rw")
+  var h5f = H5open(File, "rw")
 
   h5f.write_dataset(data, Dset)
   h5f.write_dataset(dataTup, DsetTup)
@@ -42,7 +42,7 @@ when isMainModule:
   var err = h5f.close()
   assert err >= 0
 
-  h5f = H5File(File, "r")
+  h5f = H5open(File, "r")
   h5f.assert_dataset(data, Dset)
   h5f.assert_dataset(dataTup, DsetTup)
 

--- a/tests/tContainsIterator.nim
+++ b/tests/tContainsIterator.nim
@@ -25,7 +25,7 @@ proc createDatasets(h5f: H5File) =
   expGroups.incl "/baz"
 
 when isMainModule:
-  var h5f = H5File("tContainsIterator.h5", "w")
+  var h5f = H5open("tContainsIterator.h5", "w")
   h5f.createDatasets()
 
   block Groups:

--- a/tests/tIntegerTypes.nim
+++ b/tests/tIntegerTypes.nim
@@ -31,7 +31,7 @@ proc read[T](h5f: var H5FileObj, dtype: typedesc[T]): seq[T] =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
 
   # write all datasets
   doAssert h5f.write(di64, int64).dtypeAnyKind == dkInt64
@@ -45,7 +45,7 @@ when isMainModule:
 
   var err = h5f.close()
   assert(err >= 0)
-  h5f = H5File(File, "r")
+  h5f = H5open(File, "r")
 
   doAssert h5f.read(int64) == di64
   doAssert h5f.read(int32) == di32

--- a/tests/tStringAttributes.nim
+++ b/tests/tStringAttributes.nim
@@ -23,7 +23,7 @@ proc assert_attrs(grp: var H5Group) =
 
 when isMainModule:
   var
-    h5f = H5file(File, "rw")
+    h5f = H5open(File, "rw")
 
   var grp = h5f.create_group("/")
   grp.write_attrs()
@@ -32,7 +32,7 @@ when isMainModule:
   var err = h5f.close()
   assert(err >= 0)
 
-  h5f = H5file(File, "r")
+  h5f = H5open(File, "r")
   grp = h5f["/".grp_str]
   grp.assert_attrs
 

--- a/tests/tattributes.nim
+++ b/tests/tattributes.nim
@@ -71,7 +71,7 @@ proc assert_overwrite(grp: var H5Group) =
 when isMainModule:
 
   var
-    h5f = H5file(File, "rw")
+    h5f = H5open(File, "rw")
     grp = h5f.create_group(GrpName)
     grpCp = h5f.create_group(GrpCopy)
     err: herr_t
@@ -89,7 +89,7 @@ when isMainModule:
   assert(err >= 0)
 
   # open again, again with write access to delete attributes again
-  h5f = H5File(File, "rw")
+  h5f = H5open(File, "rw")
   grp = h5f[GrpName.grp_str]
   grpCp = h5f[GrpCopy.grp_str]
   # and check again

--- a/tests/tbasic.nim
+++ b/tests/tbasic.nim
@@ -5,7 +5,7 @@ const FILE = "create_close.h5"
 
 when isMainModule:
 
-  var h5f = H5file(FILE, "rw")
+  var h5f = H5open(FILE, "rw")
 
   assert(h5f.name == FILE)
 
@@ -13,6 +13,6 @@ when isMainModule:
 
   # unless closing did not work, should return >= 0
   assert(err >= 0)
-  
-  # clean up after ourselves  
+
+  # clean up after ourselves
   removeFile(File)

--- a/tests/tblosc.nim
+++ b/tests/tblosc.nim
@@ -21,7 +21,7 @@ when isMainModule:
   echo "Blosc date: ", date
 
   # create dataset to store with filter and read back
-  var h5f = H5File(Filename, "rw")
+  var h5f = H5open(Filename, "rw")
 
   let filter =  H5Filter(kind: fkBlosc, bloscLevel: 4, doShuffle: false,
                          compressor: BloscCompressor.LZ4)

--- a/tests/tconvert.nim
+++ b/tests/tconvert.nim
@@ -18,7 +18,7 @@ proc create_dset(h5f: var H5FileObj): H5DataSet =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset = h5f.create_dset()
 
   # now read data as a different data type

--- a/tests/tcopy.nim
+++ b/tests/tcopy.nim
@@ -61,7 +61,7 @@ proc assert_file2(h5f: var H5FileObj) =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File1, "rw")
+    h5f = H5open(File1, "rw")
     dset = create_dset(h5f)
   # perform 1st checks on still open file
   h5f.assert_dset(dset, File1)
@@ -72,7 +72,7 @@ when isMainModule:
   #dset = h5f[DsetName.dset_str]
 
   # copy the dataset to file 2
-  var h5out = H5File(File2, "rw")
+  var h5out = H5open(File2, "rw")
 
   # copy dataset to another location in same file
   var success = h5f.copy(dset, target = some("/test"))

--- a/tests/tdelete.nim
+++ b/tests/tdelete.nim
@@ -19,7 +19,7 @@ proc create_dset(h5f: var H5FileObj, name: string): H5DataSet =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset1 = h5f.create_dset(DsetName1)
     dset2 = h5f.create_dset(DsetName2)
     dset3 = h5f.create_dset(DsetName3)

--- a/tests/tdset.nim
+++ b/tests/tdset.nim
@@ -1,7 +1,6 @@
 import nimhdf5
 import sequtils
 import os
-import ospaths
 
 const
   File = "tests/dset.h5"
@@ -13,11 +12,11 @@ var d_ar = @[ @[ @[1'f64, 2, 3, 4, 5],
                  @[6'f64, 7, 8, 9, 10] ] ]
 
 
-proc create_dset(h5f: var H5FileObj): H5DataSet =
+proc create_dset(h5f: var H5File): H5DataSet =
   result = h5f.create_dataset("/group1/dset", (2, 2, 5), float64)
   result[result.all] = d_ar
 
-proc assert_fields(h5f: var H5FileObj, dset: var H5DataSet, parent = DsetName) =
+proc assert_fields(h5f: var H5File, dset: var H5DataSet, parent = DsetName) =
   assert(dset.shape == @[2, 2, 5])
 
   # non resizable dataset means maxshape same as current shape
@@ -56,7 +55,7 @@ proc assert_data(dset: var H5DataSet) =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset = h5f.create_dset()
     dset2 = h5f.write_dataset(Dset2Name, d_ar)
   # perform 1st checks on still open file
@@ -66,7 +65,7 @@ when isMainModule:
   var err = h5f.close()
   assert(err >= 0)
   var
-    h5f_read = H5File(File, "r")
+    h5f_read = H5open(File, "r")
   # get same dset from before
   dset = h5f_read[DsetName.dset_str]
   dset2 = h5f_read[Dset2Name.dset_str]

--- a/tests/tempty_hyperslab.nim
+++ b/tests/tempty_hyperslab.nim
@@ -19,7 +19,7 @@ proc create_dset(h5f: var H5FileObj): H5DataSet =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset = h5f.create_dset()
 
   # write empty hyperslab

--- a/tests/tfilter.nim
+++ b/tests/tfilter.nim
@@ -12,7 +12,7 @@ const chunkSize = @[20, 20]
 
 when isMainModule:
 
-  var h5f = H5File(Filename, "rw")
+  var h5f = H5open(Filename, "rw")
 
   let filter =  H5Filter(kind: fkZlib, zlibLevel: 9)
 

--- a/tests/tgroups.nim
+++ b/tests/tgroups.nim
@@ -7,7 +7,7 @@ const
   Grp3 = "/foo/bar"
 
 when isMainModule:
-  var h5f = H5File(File, "rw")
+  var h5f = H5open(File, "rw")
 
   # manually create group
   let grp1 = h5f.create_group(Grp1)

--- a/tests/tint64_dset.nim
+++ b/tests/tint64_dset.nim
@@ -20,7 +20,7 @@ proc create_dset(h5f: var H5FileObj): H5DataSet =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset = h5f.create_dset()
   # perform 1st checks on still open file
   # close and reopen
@@ -29,7 +29,7 @@ when isMainModule:
   var err = h5f.close()
   assert(err >= 0)
   var
-    h5f_read = H5File(File, "r")
+    h5f_read = H5open(File, "r")
   # get same dset from before
   dset = h5f_read[DsetName.dset_str]
   # check if assertions still hold true (did we read correctly?)

--- a/tests/toverwrite.nim
+++ b/tests/toverwrite.nim
@@ -17,7 +17,7 @@ var d_new = @[ @[1'f64, 2, 3, 4, 5],
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
 
   template createAndOverwrite(path: string): untyped =
     var dset = h5f.create_dataset(path, (2, 5), float64)

--- a/tests/tread1D.nim
+++ b/tests/tread1D.nim
@@ -1,8 +1,6 @@
 import nimhdf5
 import sequtils
 import os
-import ospaths
-import typeinfo
 
 const
   File = "tests/dset.h5"
@@ -10,7 +8,7 @@ const
   Dset2Name = "dset2"
 const data = @[0, 1, 2 ,3, 4, 5, 6, 7, 8, 9]
 
-proc create_dset(h5f: var H5FileObj, name: string): H5DataSet =
+proc create_dset(h5f: var H5File, name: string): H5DataSet =
   result = h5f.create_dataset(name, 10, int)
   result[result.all] = data
 

--- a/tests/treshape.nim
+++ b/tests/treshape.nim
@@ -66,7 +66,7 @@ proc assert_data(dset: var H5DataSet, shape: seq[int]) =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     (dset2d, dset3d) = h5f.create_dset()
   # perform 1st checks on still open file
   assert_data(dset2d, @[3, 3])
@@ -75,7 +75,7 @@ when isMainModule:
   var err = h5f.close()
   assert(err >= 0)
   var
-    h5f_read = H5File(File, "r")
+    h5f_read = H5open(File, "r")
   # get same dset from before
   dset2d = h5f_read[Dset2D.dset_str]
   dset3d = h5f_read[Dset3D.dset_str]

--- a/tests/tresize.nim
+++ b/tests/tresize.nim
@@ -82,7 +82,7 @@ proc assert_data(dset: var H5DataSet, resized: bool) =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset = h5f.create_dset()
   # perform 1st checks on still open file
   h5f.assert_fields(dset, false)
@@ -96,7 +96,7 @@ when isMainModule:
   var err = h5f.close()
   assert(err >= 0)
   var
-    h5f_read = H5File(File, "r")
+    h5f_read = H5open(File, "r")
   # get same dset from before
   dset = h5f_read[DsetName.dset_str]
   # check if assertions still hold true (did we read correctly?)

--- a/tests/tresize_by_add.nim
+++ b/tests/tresize_by_add.nim
@@ -28,7 +28,7 @@ proc create_vlen(h5f: var H5FileObj, name: string): H5DataSet =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset = h5f.create_dset(DsetName)
     dset2 = h5f.create_dset(DsetName2)
     dsetV = h5f.create_vlen(DsetVlen)

--- a/tests/tvlen_array.nim
+++ b/tests/tvlen_array.nim
@@ -61,7 +61,7 @@ proc doAssert_data(dset: var H5DataSet) =
 when isMainModule:
   # open file, create dataset
   var
-    h5f = H5File(File, "rw")
+    h5f = H5open(File, "rw")
     dset = h5f.create_vlen()
   # perform 1st checks on still open file
   h5f.doAssert_fields(dset)
@@ -69,7 +69,7 @@ when isMainModule:
   var err = h5f.close()
   doAssert(err >= 0)
   var
-    h5f_read = H5File(File, "r")
+    h5f_read = H5open(File, "r")
   # get same dset from before
   dset = h5f_read[VlenName.dset_str]
   # check if doAssertions still hold true (did we read correctly?)


### PR DESCRIPTION
We never destroyed the references to the tables, nor the string and
seq fields.

This might cause GC problems on refc and under problems under orc.

At least it (seemed) to have caused a regression when dealing with H5
files that for some reason something attempts to close already closed
objects in a file.