### PR TITLE
Further `=destroy` fixes and raise on failed open

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,14 @@
+* v0.4.4
+- further fixes ~=destroy~ hooks introduced in =v0.4.2=. Under some
+  circumstances the defined hooks caused segmentation faults when
+  deallocating objects (these hooks are finicky!)
+- fix opening files with =akTruncate= (i.e. overwrite a file instead
+  of appending)
+- *SEMI-BREAKING*: raise an exception if opening a file failed.
+  This is more of an oversight rather than a feature that we did not
+  raise so far. This is not really *breaking* in a sense, because in
+  the past we simply failed in the =getNumAttrs= call that happened
+  when trying to open the attributes of the root group in the file.
 * v0.4.3
 - fixed the ~=destroy~ hooks introduced in =v0.4.2=
 - added support for =SWMR= (see README)

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -475,9 +475,6 @@ when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
   proc `=destroy`*(grp: var H5GroupObj) =
     ## Closes the group and resets all references to nil.
     `=destroy`(grp.file_ref) # only destroy the `ref` to the file!
-    grp.file_ref = nil # should this be destroyed?
-    grp.file_id = -1.FileID
-    grp.parent_id = ParentID(kind: okNone)
     grp.close()
     grp.opened = false
     if grp.datasets != nil:
@@ -488,8 +485,7 @@ when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
       `=destroy`(grp.attrs)
     for name, field in fieldPairs(grp):
       if name notin ["attrs", "groups", "datasets", "file_ref"]:
-        when typeof(field) is string or typeof(field) is seq:
-          `=destroy`(field)
+        `=destroy`(field)
 
   when false:
     ## currently these are problematic, as we're allowed to just copy these IDs in Nim land,

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -456,14 +456,10 @@ when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
   proc `=destroy`*(attrs: var H5AttributesObj) =
     ## Closes all attributes that are stored in this `H5Attributes` table.
     if attrs.attr_tab != nil:
-      for name, attr in mpairs(attrs.attr_tab):
-        if attr != nil:
-          `=destroy`(attr)
       `=destroy`(attrs.attr_tab)
     for name, field in fieldPairs(attrs):
       if name != "attr_tab":
-        when typeof(field) is string or typeof(field) is seq:
-          `=destroy`(field)
+        `=destroy`(field)
 
   proc `=destroy`*(dset: var H5DataSetObj) =
     ## Closes the dataset and resets all references to nil.

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -90,7 +90,7 @@ proc H5open*(name, rwType: string, accessFlags: set[AccessKind] = {}): H5File =
   result.accessFlags = flags
   if akInvalid in flags:
      raise newException(IOError, getH5rw_invalid_error())
-  elif exists:
+  elif exists and akTruncate notin flags:
     ## open existing file
     result.file_id = H5Fopen(name, flags.toH5(), H5P_DEFAULT).FileID
   elif not exists and akRead in flags:

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -101,6 +101,12 @@ proc H5open*(name, rwType: string, accessFlags: set[AccessKind] = {}): H5File =
     withDebug:
       echo "Flags is  ", flags
     result.file_id = H5Fcreate(name, flags.toH5(), H5P_DEFAULT, H5P_DEFAULT).FileID
+
+  if result.file_id.hid_t < 0.hid_t:
+    raise newException(HDF5LibraryError, "Failed to open file " & $name & " using rwType: \"" & $rwType &
+      "\" and access flags: " & $accessFlags)
+
+
   # after having opened / created the given file, we get the datasets etc.
   # which are stored in the file
   result.attrs = initH5Attributes(ParentID(kind: okFile,


### PR DESCRIPTION
The `=destroy` hooks were still buggy. Under certain use cases they could cause segfaults.

We now raise if we failed to open a H5 file. While this is a breaking change in theory, it isn't in practice. In the past we would have simply raised a few lines later in the code when trying to get the number of attributes of the root group in the file. This especially is a hard to understand error.

Finally, this also fixes the `akTruncate` flag of overwriting a file instead of appending, by calling `H5Fcreate` in case of its usage instead of `H5Fopen`.

Unfortunately, writing tests for the old segfaults is hard to do. They only appeared in complex use cases of opening and closing a bunch of files. :/