### PR TITLE
VLEN improvements, fix `copy` regression

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,13 @@
+* v0.4.6
+- avoid copy of input data when writing VLEN data
+- CT error if composite data with string fields is being read, as it's
+  currently not supported (strings are vlen data & vlen in composite
+  isn't implemented)
+- fix regression in =copy= due to =distinct hid_t= variants
+- extend =withDset= to work properly with vlen data (returning =dset=
+  variable with =seq[seq[T]]=) and add =withDset= overload working
+  with a H5 file and a string name of a dataset
+- add test case for =withDset=  
 * v0.4.5
 - treat =akTruncate= flag as write access to the file
   (=create_dataset= was not working with it)

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -39,6 +39,7 @@ task test, "Runs all tests":
   exec "nim c -r tests/tint64_dset.nim"
   exec "nim c -r tests/t17.nim"
   exec "nim c -r tests/tIntegerTypes.nim"
+  exec "nim c -r tests/tWithDset.nim"
   # at least run the high level examples to avoid regressions
   if fileExists("dset.h5"): # as a test, we need to get rid of the high level H5 output file
     rmFile("dset.h5")

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -590,8 +590,7 @@ proc `[]=`*[T](dset: H5DataSet, ind: DsetReadWrite, data: seq[T]) =
         # in the file in this case we need to prepare the data further by
         # assigning the data to a hvl_t struct
         when T is seq:
-          var mdata = data
-          var data_hvl = mdata.toH5vlen
+          var data_hvl = data.toH5vlen
           err = H5Dwrite(dset.dataset_id.hid_t,
                          dset.dtype_c.hid_t,
                          H5S_ALL,

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -806,6 +806,13 @@ proc readAs*[T: SomeNumber](h5f: H5File, dset: string, dtype: typedesc[T]): seq[
 
 proc read*[T](dset: H5DataSet, buf: var seq[T]) =
   ## read whole dataset
+  ## XXX: handle string fields instead of erroring!
+  when T is object:
+    if buf.len > 0:
+      for field in fields(buf[0]):
+        when typeof(field) is string:
+          {.error: "Reading data of objects with string fields currently still unsupported! " &
+            "The relevant type is: " & $T & " with string field: " & $astToStr(field).}
   if buf.len == foldl(dset.shape, a * b, 1):
     discard H5Dread(dset.dataset_id.hid_t, dset.dtype_c.hid_t, H5S_ALL, H5S_ALL, H5P_DEFAULT,
                     addr(buf[0]))

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -1061,48 +1061,90 @@ template withDset*(h5dset: H5DataSet, actions: untyped) =
   ## convenience template to read a dataset from the file and perform actions
   ## with that dataset, without having to manually check the data type of the
   ## dataset
-  let dtype = if h5dset.dtypeAnyKind == dkSequence: h5dset.dtypeBaseKind
-              else: h5dset.dtypeAnyKind
-  case dtype
+  case h5dset.dtypeAnyKind
   of dkBool:
-    let dset {.inject.} = h5dset.read(bool, allowVlen = true)
+    let dset {.inject.} = h5dset.read(bool)
     actions
   of dkChar:
-    let dset {.inject.} = h5dset.read(char, allowVlen = true)
+    let dset {.inject.} = h5dset.read(char)
     actions
   of dkString:
-    let dset {.inject.} = h5dset.read(string, allowVlen = true)
+    let dset {.inject.} = h5dset.read(string)
     actions
   of dkFloat32:
-    let dset {.inject.} = h5dset.read(float32, allowVlen = true)
+    let dset {.inject.} = h5dset.read(float32)
     actions
   of dkFloat64:
-    let dset {.inject.} = h5dset.read(float64, allowVlen = true)
+    let dset {.inject.} = h5dset.read(float64)
     actions
   of dkInt8:
-    let dset {.inject.} = h5dset.read(int8, allowVlen = true)
+    let dset {.inject.} = h5dset.read(int8)
     actions
   of dkInt16:
-    let dset {.inject.} = h5dset.read(int16, allowVlen = true)
+    let dset {.inject.} = h5dset.read(int16)
     actions
   of dkInt32:
-    let dset {.inject.} = h5dset.read(int32, allowVlen = true)
+    let dset {.inject.} = h5dset.read(int32)
     actions
   of dkInt64:
-    let dset {.inject.} = h5dset.read(int64, allowVlen = true)
+    let dset {.inject.} = h5dset.read(int64)
     actions
   of dkUint8:
-    let dset {.inject.} = h5dset.read(uint8, allowVlen = true)
+    let dset {.inject.} = h5dset.read(uint8)
     actions
   of dkUint16:
-    let dset {.inject.} = h5dset.read(uint16, allowVlen = true)
+    let dset {.inject.} = h5dset.read(uint16)
     actions
   of dkUint32:
-    let dset {.inject.} = h5dset.read(uint32, allowVlen = true)
+    let dset {.inject.} = h5dset.read(uint32)
     actions
   of dkUint64:
-    let dset {.inject.} = h5dset.read(uint64, allowVlen = true)
+    let dset {.inject.} = h5dset.read(uint64)
     actions
+  of dkSequence:
+    # need to perform same game again...
+    case h5dset.dtypeBaseKind
+    of dkBool:
+      let dset {.inject.} = h5dset.readVlen(bool)
+      actions
+    of dkChar:
+      let dset {.inject.} = h5dset.readVlen(char)
+      actions
+    of dkString:
+      let dset {.inject.} = h5dset.readVlen(string)
+      actions
+    of dkFloat32:
+      let dset {.inject.} = h5dset.readVlen(float32)
+      actions
+    of dkFloat64:
+      let dset {.inject.} = h5dset.readVlen(float64)
+      actions
+    of dkInt8:
+      let dset {.inject.} = h5dset.readVlen(int8)
+      actions
+    of dkInt16:
+      let dset {.inject.} = h5dset.readVlen(int16)
+      actions
+    of dkInt32:
+      let dset {.inject.} = h5dset.readVlen(int32)
+      actions
+    of dkInt64:
+      let dset {.inject.} = h5dset.readVlen(int64)
+      actions
+    of dkUint8:
+      let dset {.inject.} = h5dset.readVlen(uint8)
+      actions
+    of dkUint16:
+      let dset {.inject.} = h5dset.readVlen(uint16)
+      actions
+    of dkUint32:
+      let dset {.inject.} = h5dset.readVlen(uint32)
+      actions
+    of dkUint64:
+      let dset {.inject.} = h5dset.readVlen(uint64)
+      actions
+    else:
+      echo "WARNING: `withDset` for type of ", h5dset.dtypeBaseKind, " not supported"
   else:
     echo "WARNING: `withDset` nothing to do, dataset is of type ", h5dset.dtypeAnyKind
     discard

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -241,6 +241,14 @@ proc create_dataset*[T: (tuple | int | seq)](
   elif T is seq:
     let shape_seq = shape
 
+  when dtype is seq or dtype is DatatypeID:
+    ## Check if given `shape` is not causing problems
+    if shape_seq.len != 1 and shape_seq[1].int > 1:
+      raise newException(ValueError, "The `dtype` argument is " & $dtype & " for the `create_dataset` " &
+        "call for the dataset: " & $dset & ". This implies a variable length (VLEN) dataset. The given " &
+        "shape: " & $shape & " however is not 1 dimensional. For a VLEN dataset only give the " &
+        "*number* of variable length elements to store!")
+
   # given dset name, either get or create group in which it belongs
   let group = create_group(h5f, dsetName.getParent) # getOrCreateGroup(h5f, dset.parent)
 

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -1058,9 +1058,12 @@ template `[]`*(grp: H5Group, dsetName: dset_str): H5DataSet =
   grp.file_ref[(grp.name / dsetName.string).dset_str]
 
 template withDset*(h5dset: H5DataSet, actions: untyped) =
-  ## convenience template to read a dataset from the file and perform actions
+  ## Convenience template to read a dataset from the file and perform actions
   ## with that dataset, without having to manually check the data type of the
-  ## dataset
+  ## dataset.
+  ##
+  ## Simply reads all the data of the given dataset into the injected `dset`
+  ## variable.
   case h5dset.dtypeAnyKind
   of dkBool:
     let dset {.inject.} = h5dset.read(bool)
@@ -1148,6 +1151,13 @@ template withDset*(h5dset: H5DataSet, actions: untyped) =
   else:
     echo "WARNING: `withDset` nothing to do, dataset is of type ", h5dset.dtypeAnyKind
     discard
+
+template withDset*(h5f: H5File, name: string, actions: untyped) =
+  ## Version of `withDset`, which acts on an input file and a dataset given by
+  ## a string name.
+  let h5dset = h5f[name.dset_str]
+  withDset(h5dset):
+    actions
 
 proc h5SelectHyperslab(dspace_id: DataspaceID | MemspaceID | HyperslabID,
                        offset, count, stride, blk: var seq[hsize_t]): herr_t {.inline.} =

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -870,11 +870,11 @@ proc getH5read_non_exist_file*(filename: string): string =
   result = &"Cannot open a non-existing file {filename} with read only access. Write " &
     "access will create the file for you."
 
-template toH5vlen*[T](data: var seq[T]): untyped =
+template toH5vlen*[T](data: seq[T]): untyped =
   when T is seq:
     mapIt(toSeq(0..data.high)) do:
       if data[it].len > 0:
-        hvl_t(`len`: csize_t(data[it].len), p: addr(data[it][0]))
+        hvl_t(`len`: csize_t(data[it].len), p: unsafeAddr(data[it][0]))
       else:
         hvl_t(`len`: csize_t(0), p: nil)
   else:

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -801,7 +801,7 @@ proc nimToH5type*(dtype: typedesc): DatatypeID =
     res = H5Tcreate(H5T_COMPOUND, sizeof(dtype).csize_t)
     walkObjectAndInsert(tmpH5, res)
   elif dtype is seq:
-    res = special_type(getInnerType(dtype))
+    res = special_type(getInnerType(dtype)).hid_t ## NOTE: back conversion to hid_t
   result = res.DatatypeID
 
 template anyTypeToString*(dtype: DtypeKind): string =

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -7,7 +7,7 @@
 # procs related to general H5 objects.
 
 import std / [strutils, strformat, options, tables, sequtils]
-from os import `/`
+from os import `/`, parentDir, extractFilename
 
 # nimhdf5 related libraries
 import hdf5_wrapper, H5nimtypes, util, datatypes
@@ -489,24 +489,24 @@ proc copy*[T](h5in: H5File, h5o: T,
     var h5f = h5out.get
     if target.isSome:
       let grp = h5f.create_group(targetGrp)
-      targetId = grp.group_id
+      targetId = grp.group_id.hid_t
     else:
       echo "Target grp ", targetGrp
       echo "Target Name ", targetName
       let grp = h5f.create_group(targetName.parentDir)
-      targetId = grp.group_id
+      targetId = grp.group_id.hid_t
   else:
     if target.isSome:
       if targetGrp == "/":
-        targetId = h5in.file_id
+        targetId = h5in.file_id.hid_t
       else:
         let grp = h5in.create_group(targetGrp)
-        targetId = grp.group_id
+        targetId = grp.group_id.hid_t
     else:
       raise newException(HDF5LibraryError, "Cannot copy object " & h5o.name & " to " &
         "same file without target!")
 
-  let err = H5Ocopy(h5o.getH5Id, h5o.name,
+  let err = H5Ocopy(h5o.getH5Id.to_hid_t, h5o.name,
                     targetId, targetName,
                     H5P_DEFAULT, H5P_DEFAULT)
 

--- a/tests/tWithDset.nim
+++ b/tests/tWithDset.nim
@@ -1,0 +1,83 @@
+import nimhdf5
+import sequtils
+import os
+
+const
+  File = "tests/tWithDset.h5"
+  di64 = @[1'i64, 2, 3, 4]
+  diS64 = di64.mapIt(di64)
+
+proc write[T; U](h5f: var H5FileObj, data: seq[T], dtype: typedesc[U]): H5DataSet =
+  when T is seq:
+    result = h5f.create_dataset("/dsetS" & $dtype, data.len, seq[dtype])
+    result[result.all] = data
+  else:
+    result = h5f.create_dataset("/dset" & $dtype, data.len, dtype)
+    result[result.all] = data
+  echo result
+
+template writeData(typ, dkind: untyped): untyped {.dirty.} =
+  block:
+    doAssert h5f.write(di64.mapIt(it.typ), typ).dtypeAnyKind == dkind
+    var data = di64.mapIt(di64.mapIt(it.typ))
+    let dset = h5f.write(data, typ)
+    doAssert dset.dtypeAnyKind == dkSequence
+    doAssert dset.dtypeBaseKind == dkind
+
+template readData(typ, dkind): untyped {.dirty.} =
+  block:
+    let h5dset = h5f[("/dset" & $typ).dset_str]
+    withDset(h5dset):
+      let tmp = di64.mapIt(it.typ)
+      when typeof(tmp) is typeof(dset): ## Need to use this when, as this code is only valid
+                                        ## in the correct type branch.
+        doAssert tmp == dset
+    let h5dsetS = h5f[("/dsetS" & $typ).dset_str]
+    withDset(h5dsetS):
+      let tmp = di64.mapIt(di64.mapIt(it.typ))
+      when typeof(tmp) is typeof(dset):
+        doAssert tmp == dset
+
+    ## one case is enough for `withDset` overload taking a dset name
+    h5f.withDset("/dsetS" & $typ):
+      let tmp = di64.mapIt(di64.mapIt(it.typ))
+      when typeof(tmp) is typeof(dset):
+        doAssert tmp == dset
+
+when isMainModule:
+  # open file, create dataset
+  var
+    h5f = H5open(File, "rw")
+
+  # write all datasets
+  writeData(int64,   dkInt64)
+  writeData(int32,   dkInt32)
+  writeData(int16,   dkInt16)
+  writeData( int8,   dkInt8)
+  writeData(uint64,  dkUInt64)
+  writeData(uint32,  dkUInt32)
+  writeData(uint16,  dkUInt16)
+  writeData( uint8,  dkUInt8)
+  writeData(float32, dkFloat32)
+  writeData(float64, dkFloat64)
+
+  var err = h5f.close()
+  assert(err >= 0)
+  h5f = H5open(File, "r")
+
+  readData(int64,   dkInt64)
+  readData(int32,   dkInt32)
+  readData(int16,   dkInt16)
+  readData( int8,   dkInt8)
+  readData(uint64,  dkUInt64)
+  readData(uint32,  dkUInt32)
+  readData(uint16,  dkUInt16)
+  readData( uint8,  dkUInt8)
+  readData(float32, dkFloat32)
+  readData(float64, dkFloat64)
+
+  err = h5f.close()
+  assert(err >= 0)
+
+  # clean up after ourselves
+  removeFile(File)

--- a/tests/tvlen_array.nim
+++ b/tests/tvlen_array.nim
@@ -17,6 +17,13 @@ proc create_vlen(h5f: var H5FileObj): H5DataSet =
   result = h5f.create_dataset("/group1/vlen", 4, vlen_type)
   result[result.all] = d_vlen
 
+  ## now check that handing the *shape* of the input data fails:
+  try:
+    discard h5f.create_dataset("/group1/vlen2", d_vlen.shape, vlen_type)
+    doAssert false, "`create_dataset` should have failed!"
+  except ValueError:
+    doAssert true
+
 proc doAssert_fields(h5f: var H5FileObj, dset: var H5DataSet) =
   doAssert(dset.maxshape == dset.shape)
 


### PR DESCRIPTION
Some small VLEN quality of life improvements (proper support in `withDset`), a regression fix in `special_type` and raising if user input is bad for `create_dataset`.

Further fixes a regression in `copy` due to the `distinct hid_t` type introductions.