### PR TITLE
add `overwrite` option to `write_dataset` helper

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.4.7
+- add =overwrite= option to =write_dataset= convenience proc
 * v0.4.6
 - avoid copy of input data when writing VLEN data
 - CT error if composite data with string fields is being read, as it's

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -347,10 +347,11 @@ proc create_dataset*[T: (tuple | int | seq)](
                               filter,
                               overwrite = overwrite)
 
-proc write_dataset*[TT](h5f: H5File, name: string, data: TT): H5DataSet =
+proc write_dataset*[TT](h5f: H5File, name: string, data: TT,
+                        overwrite = false): H5DataSet =
   ## convenience proc to create a dataset and write data it immediately
   type T = getInnerType(TT)
-  result = h5f.create_dataset(name, data.shape, T)
+  result = h5f.create_dataset(name, data.shape, T, overwrite = overwrite)
   result[result.all] = data
 
 proc unsafeWrite*[T](dset: H5DataSet, data: ptr T, length: int) =


### PR DESCRIPTION
This was still missing and is quite useful...