### PR TITLE
Fix `delete` to correctly remove elements from `groups/datasets` `TableRef`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,28 @@
+* v0.4.8
+- fix behavior of =delete= to make sure we also keep our internal
+  =TableRef= in line with the file
+- fully support writing datasets as =(N, )= instead of turning it into =(N,
+  1)= instead (especially for VLEN data).
+  This has big implications when reading 1D data using hyperslabs. If
+  instead of adding an extra dimension as:
+  #+begin_src nim
+  let data = dset.read_hyperslab(dtype, start = @[1000, 0], count = @[1000, 1])
+  #+end_src
+  instead of
+  #+begin_src nim
+  let data = dset.read_hyperslab(dtype, start = @[1000], count = @[1000])
+  #+end_src
+  reading performance is *orders of magnitudes* slower!
+  Essentially when handing an integer to =create_datasets= it is now
+  kept as such (and turned into a 1 element tuple). 
+  For non vlen data creating and writing such datasets correctly
+  worked correctly before if I'm not mistaken.
+- add more exception types for dealing with filters & in particular
+  =blosc=:
+  - =HDF5FilterError=
+  - =HDF5DecompressionError=
+  - =HDF5BloscFilterError=
+  - =HDF5BloscDecompressionError=
 * v0.4.7
 - add =overwrite= option to =write_dataset= convenience proc
 * v0.4.6

--- a/examples/h5_high_level_example.nim
+++ b/examples/h5_high_level_example.nim
@@ -293,7 +293,7 @@ proc read_some() =
   g1.echo_in_file("dset1D")
   doAssert "/group1/group2" in g1
   doAssert "group2" in g1
-  doAssert "/group2" in g1
+  doAssert "./group2" in g1
 
   # close the file again
   discard file.close()

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -229,10 +229,8 @@ proc create_dataset*[T: (tuple | int | seq)](
   ## TODO: should create_dataset fail by default if the dataset exists?
 
   when T is int:
-    # in case we hand an int as the shape argument, it means we wish to write
-    # 1 column data to the file. In this case define the shape from here on
-    # as a (shape, 1) tuple instead.
-    let shape = (shape, 1)
+    # in this case deal with regular 1D array. Just keep it as 1 element tuple
+    let shape = (shape, )
     # need to deal with the shape of the dataset to be created
     let shape_seq = parseShapeTuple(shape)
   elif T is tuple:
@@ -581,9 +579,7 @@ proc `[]=`*[T](dset: H5DataSet, ind: DsetReadWrite, data: seq[T]) =
     # shapes. We compare shape[1] with 1, because atm we demand VLEN data to be
     # a 2D array with one column. While in principle it's a N element vector
     # it is always promoted to a (N, 1) array.
-    if (shape.len == 2 and shape[1] == 1 and shape(data)[0] == dset.shape[0]) or
-      data.shape == dset.shape:
-
+    if shape[0] == data.shape[0]:
       if dset.dtype_class == H5T_VLEN:
         # TODO: should we also check whether data really is 1D? or let user
         # deal with that? will flatten the array anyways, so in case on tries

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -224,6 +224,12 @@ type
   ReadOnlyError* = object of CatchableError
   # raised if some part of code that is not yet implemented (but planned) is being called
   NotImplementedError* = object of Defect
+  # raised for generic exceptions in context of filters
+  HDF5FilterError* = object of HDF5LibraryError
+  # raised if decompression call fails
+  HDF5DecompressionError* = object of HDF5FilterError
+
+
 
   # enum which determines how the given H5 object should be flushed
   # corresponds to the H5F_SCOPE flags

--- a/src/nimhdf5/filters.nim
+++ b/src/nimhdf5/filters.nim
@@ -91,5 +91,5 @@ proc setFilters*(dset: H5DataSet, filter: H5Filter) =
     discard
 
   if status < 0:
-    raise newException(Hdf5LibraryError, "Call to hdf5 library failed in " &
+    raise newException(HDF5FilterError, "Call to hdf5 library failed in " &
       "`setFilters` trying to set " & $filter.kind & " filter.")

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -427,6 +427,26 @@ proc contains*(h5f: H5File, name: string): bool =
   let fileId = h5f.file_id
   result = existsInFile(fileId, name) > 0
 
+proc formatMaybeRelativeName*[T](h5o: T, name: string): string =
+  ## Formats the given `name` taking into account that it may be a relative name
+  ## starting from the given `h5o` or may be an absolute path.
+  when T is H5File:
+    # must be absolute
+    result = name.formatName() # possibly prepend `/`
+  else:
+    # 1. if starts with `/`, treat as absolute
+    if name.startsWith("/"):
+      result = name.formatName()
+    else:
+      # check if relative
+      let n = name.formatName()
+      if n.startsWith(h5o.name):
+        # is absolute
+        result = n
+      else:
+        # is relative, prepend object name
+        result = formatName(h5o.name / name)
+
 proc contains*(grp: H5Group, name: string): bool =
   ## Checks if the given `name` is a subgroup or dataset in `grp` or its groups.
   ## nIt takes a parent-child relationship for groups into account, i.e. if called

--- a/src/nimhdf5/util.nim
+++ b/src/nimhdf5/util.nim
@@ -9,7 +9,7 @@
 # of the H5 library (although the purpose of the function might)
 # and does not make use of any datatypes defined for H5 interop.
 
-import std / [strutils, macros, os]
+import std / [strutils, macros, os, pathnorm]
 
 template withDebug*(actions: untyped) =
   ## a debugging template, which can be used to e.g. output
@@ -25,7 +25,8 @@ proc formatName*(name: string): string =
   # a potentially missing root / and removing a potential trailing /
   # do this by trying to strip any leading and trailing / from name (plus newline,
   # whitespace, if any) and then prepending a leading /
-  result = "/" & strip(name, chars = ({'/'} + Whitespace + NewLines))
+  # Note: we use `normalizePath` only for the behavior of `./`, `..` and multiple `/`
+  result = "/" & name.normalizePath().strip(chars = ({'/'} + Whitespace + NewLines))
 
 template getParent*(dset_name: string): string =
   ## given a `dset_name` after formating (!), return the parent name,

--- a/tests/tdelete.nim
+++ b/tests/tdelete.nim
@@ -1,5 +1,5 @@
 import nimhdf5
-import sequtils
+import sequtils, tables
 import os
 import ospaths
 import typeinfo
@@ -32,24 +32,43 @@ when isMainModule:
   doAssert "group2/dset" in h5f
   doAssert "group3/dset" in h5f
 
+  doAssert "/group" in h5f.groups
+  doAssert "/group2" in h5f.groups
+  doAssert "/group3" in h5f.groups
+  doAssert "/group/dset" in h5f.datasets
+  doAssert "/group2/dset" in h5f.datasets
+  doAssert "/group3/dset" in h5f.datasets
+
+
   # now delete
   # first delete only dset then group
   doAssert h5f.delete("group/dset")
   doAssert "group/dset" notin h5f
+  doAssert "/group/dset" notin h5f.datasets
   doAssert h5f.delete("group")
   doAssert "group" notin h5f
+  doAssert "/group" notin h5f.groups
 
   # now delete group2 and its contents
   doAssert h5f.delete("group2")
   doAssert "group2" notin h5f
+  doAssert "/group2" notin h5f.groups
   doAssert "group2/dset" notin h5f
+  doAssert "/group2/dset" notin h5f.datasets
 
   # finally delete group3/dset from relative group3
   var grp3 = h5f["group3".grp_str]
   doAssert grp3.delete("dset")
   doAssert "group3/dset" notin h5f
+  doAssert "/group3/dset" notin h5f.datasets
+  doAssert "group3/dset" notin grp3
+  doAssert "/group3/dset" notin grp3.datasets
   doAssert h5f.delete("group3")
   doAssert "group3" notin h5f
+  doAssert "/group3" notin h5f.groups
+
+  doAssert h5f.groups.len == 0
+  doAssert h5f.datasets.len == 0
 
   var err = h5f.close()
   doAssert(err >= 0)

--- a/tests/tread1D.nim
+++ b/tests/tread1D.nim
@@ -13,7 +13,7 @@ proc create_dset(h5f: var H5File, name: string): H5DataSet =
   result[result.all] = data
 
 proc assert_fields(dset: H5DataSet) =
-  assert(dset.shape == @[10, 1])
+  assert(dset.shape == @[10])
   assert(dset.dtype == "int64")
 
 proc assert_data(dset: var H5DataSet) =

--- a/tests/tutil.nim
+++ b/tests/tutil.nim
@@ -1,27 +1,35 @@
 import nimhdf5, sequtils
 
-# some hdf5 independent tests for the util module
-# currently only for newSeq and reshape procs
-
 when isMainModule:
 
-  assert newSeqOf2D[int](@[9, 9]).shape == @[9, 9]
-  assert newSeqOf2D[int]([9, 9]).shape == @[9, 9]
+  block ShapeAndSeq:
+    doAssert newSeqOf2D[int](@[9, 9]).shape == @[9, 9]
+    doAssert newSeqOf2D[int]([9, 9]).shape == @[9, 9]
 
-  assert newSeqOf3D[int](@[2, 2, 5]).shape == @[2, 2, 5]
-  assert newSeqOf3D[int](@[5, 5, 5]).shape == @[5, 5, 5]
-  assert newSeqOf3D[int](@[10, 5, 15]).shape == @[10, 5, 15]
-  assert newSeqOf3D[int]([2, 2, 5]).shape == @[2, 2, 5]
+    doAssert newSeqOf3D[int](@[2, 2, 5]).shape == @[2, 2, 5]
+    doAssert newSeqOf3D[int](@[5, 5, 5]).shape == @[5, 5, 5]
+    doAssert newSeqOf3D[int](@[10, 5, 15]).shape == @[10, 5, 15]
+    doAssert newSeqOf3D[int]([2, 2, 5]).shape == @[2, 2, 5]
 
-  let
-    s1 = newSeq[int](81)
-    s2 = newSeq[int](4 * 5 * 6)
-    s3 = newSeq[float](10 * 10 * 10)
-  assert s1.reshape([9, 9]).shape == @[9, 9]
-  assert s1.reshape2D(@[9, 9]).shape == @[9, 9]
+    let
+      s1 = newSeq[int](81)
+      s2 = newSeq[int](4 * 5 * 6)
+      s3 = newSeq[float](10 * 10 * 10)
+    doAssert s1.reshape([9, 9]).shape == @[9, 9]
+    doAssert s1.reshape2D(@[9, 9]).shape == @[9, 9]
 
-  assert s2.reshape([4, 5, 6]).shape == @[4, 5, 6]
-  assert s2.reshape3D(@[4, 5, 6]).shape == @[4, 5, 6]
+    doAssert s2.reshape([4, 5, 6]).shape == @[4, 5, 6]
+    doAssert s2.reshape3D(@[4, 5, 6]).shape == @[4, 5, 6]
 
-  assert s3.reshape([10, 10, 10]).shape == @[10, 10, 10]
-  assert s3.reshape3D(@[10, 10, 10]).shape == @[10, 10, 10]
+    doAssert s3.reshape([10, 10, 10]).shape == @[10, 10, 10]
+    doAssert s3.reshape3D(@[10, 10, 10]).shape == @[10, 10, 10]
+
+
+  block Format:
+    doAssert "foo".formatName() == "/foo"
+    doassert "foo//".formatName() == "/foo"
+    doAssert "/foo".formatName() == "/foo"
+    doAssert "/foo/bar".formatName() == "/foo/bar"
+    doAssert "/foo/bar/".formatName() == "/foo/bar"
+    doAssert "/foo//bar/".formatName() == "/foo/bar"
+    doAssert "/foo//bar/\n".formatName() == "/foo/bar"


### PR DESCRIPTION
The handling of names in the `delete` proc was problematic, as we could delete elements from the file, but not the `groups` / `datasets` tables of the object (if the name was not correctly formatted in the input).

Further, datasets were not removed that are stored in a group, which is deleted. 

edit: the following will be handled in the future. I depend on the added changes.
- [ ] fix iterators for `groups` (and maybe `datasets`?) to yield the correct data. Currently the `depth` argument is off by 1 level. The `items` iterator for files works correctly however.