### PR TITLE
More overloads working with `ptr T`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-6, devel]
+        branch: [version-1-4, version-1-6, devel]
         target: [linux] #, macos, windows]
         include:
           - target: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-2, version-1-4, devel]
+        branch: [version-1-6, devel]
         target: [linux] #, macos, windows]
         include:
           - target: linux

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,12 @@
+* v0.5.2
+- remove support for reading into a ~cstring~, as this is not well
+  defined. A local cstring that needs to be created cannot be returned
+  (without dealing manually with allocations)
+- add ~add~, ~write_hyperslab~, ~read~ working with ~ptr T~ for direct
+  access with a manual memory region (useful when working with things
+  like ~Tensors~)
+- reorder ~dataset.nim~ code a little bit
+- support ~openArray~ in more places    
 * v0.5.1
 - (finally!) add support for =string= datasets
   - fixed length string datasets, written by constructing a

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -10,7 +10,7 @@ skipExt       = @["nim~"]
 
 # Dependencies
 
-requires "nim >= 1.0.0"
+requires "nim >= 1.6.0"
 requires "https://github.com/vindaar/seqmath >= 0.1.17"
 # for blosc support install:
 # requires "nblosc >= 1.15.0"

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -10,7 +10,7 @@ skipExt       = @["nim~"]
 
 # Dependencies
 
-requires "nim >= 1.6.0"
+requires "nim >= 1.4.0"
 requires "https://github.com/vindaar/seqmath >= 0.1.17"
 # for blosc support install:
 # requires "nblosc >= 1.15.0"

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -11,7 +11,7 @@ skipExt       = @["nim~"]
 # Dependencies
 
 requires "nim >= 1.0.0"
-requires "https://github.com/vindaar/seqmath >= 0.1.12"
+requires "https://github.com/vindaar/seqmath >= 0.1.17"
 # for blosc support install:
 # requires "nblosc >= 1.15.0"
 

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -1738,10 +1738,10 @@ proc add*[T: seq|openArray](dset: H5DataSet, data: openArray[T], axis = 0, rewri
   ## written back to file.
   if dset.isVlen:
     let data_hvl = data.toH5vlen()
-    dset.add(data_hvl[0].addr, @[data.shape[0], 1], axis, rewriteAsChunked)
+    dset.add(data_hvl[0].unsafeAddr, @[data.shape[0], 1], axis, rewriteAsChunked)
   else:
     let flat = data.flatten
-    dset.add(flat[0].addr, data.shape, axis, rewriteAsChunked)
+    dset.add(flat[0].unsafeAddr, data.shape, axis, rewriteAsChunked)
 
 proc add*[T: not (seq|openArray)](dset: H5DataSet, data: openArray[T], axis = 0, rewriteAsChunked = false) =
   ## Note: for 1D data (not VLEN)
@@ -1756,7 +1756,7 @@ proc add*[T: not (seq|openArray)](dset: H5DataSet, data: openArray[T], axis = 0,
   if dset.isVlen:
     raise newException(ValueError, "Cannot write 1D data to a VLEN dataset " & $dset.name)
   else:
-    dset.add(data[0].addr, data.shape, axis, rewriteAsChunked)
+    dset.add(data[0].unsafeAddr, data.shape, axis, rewriteAsChunked)
 
 proc open*(h5f: H5File, dset: dset_str) =
   ## Opens the given `dset` and updates the data stored in the `datasets` table of

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -503,7 +503,7 @@ proc `[]=`*[T](dset: H5DataSet, ind: DsetReadWrite, data: seq[T]) =
 # Forward declare read and write hyperslab procedures for convenience
 # writing / reading procedures (for the case of slices)
 proc write_hyperslab*[T](dset: H5DataSet,
-                         data: seq[T],
+                         data: openArray[T],
                          offset,
                          count: seq[int],
                          stride, blk: seq[int] = @[])

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -1487,7 +1487,7 @@ proc write_hyperslab*[T](
     else:
       template mdata(): untyped = data # already flat!
     write_hyperslab(dset,
-                    mdata[0].addr,
+                    mdata[0].unsafeAddr,
                     data.shape,
                     offset, count, stride, blk)
 

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -928,8 +928,8 @@ proc getH5read_non_exist_file*(filename: string): string =
     "access will create the file for you."
 
 import sequtils
-template toH5vlen*[T](data: seq[T]): untyped =
-  when T is seq or T is string or T is cstring:
+template toH5vlen*[T](data: openArray[T]): untyped =
+  when T is (seq|openArray) or T is string or T is cstring:
     mapIt(toSeq(0..data.high)) do:
       if data[it].len > 0:
         hvl_t(`len`: csize_t(data[it].len), p: unsafeAddr(data[it][0]))

--- a/tests/tContainsIterator.nim
+++ b/tests/tContainsIterator.nim
@@ -1,5 +1,7 @@
 import nimhdf5, sets, unittest, sets, strutils
+from os import removeFile
 
+const File = "tests/tContainsIterator.h5"
 var expDsets = initHashSet[string]()
 var expGroups = initHashSet[string]()
 proc createDatasets(h5f: H5File) =
@@ -25,7 +27,7 @@ proc createDatasets(h5f: H5File) =
   expGroups.incl "/baz"
 
 when isMainModule:
-  var h5f = H5open("tContainsIterator.h5", "w")
+  var h5f = H5open(File, "w")
   h5f.createDatasets()
 
   block Groups:
@@ -106,3 +108,8 @@ when isMainModule:
     check "foo/data" in h5f
     check "data" in rootGrp # insensitive to `/` as there is a data in the root
     check "foo/data" in rootGrp
+
+  let err = h5f.close()
+  assert err >= 0
+
+  removeFile(File)


### PR DESCRIPTION
*WARNING*: This drops support for Nim versions < 1.6. I don't feel like playing the annoying support game for a library hardly anyone uses. If I'm wrong and you need some older version, open an issue and I'll support that version. 
edit: oh for fucks sake. Guess `addr` is still not a thing in 1.6 even, ugh. 

```
* v0.5.2
- remove support for reading into a ~cstring~, as this is not well
  defined. A local cstring that needs to be created cannot be returned
  (without dealing manually with allocations)
- add ~add~, ~write_hyperslab~, ~read~ working with ~ptr T~ for direct
  access with a manual memory region (useful when working with things
  like ~Tensors~)
- reorder ~dataset.nim~ code a little bit
- support ~openArray~ in more places
```