### PR TITLE
Basic serialization for objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-4, version-1-6, devel]
+        branch: [version-1-6, devel]
         target: [linux] #, macos, windows]
         include:
           - target: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,13 @@ jobs:
           cd nimhdf5
           nimble refresh -y
           nimble install -y
+          nimble -y testDeps
 
       - name: Run tests
         shell: bash
         run: |
           cd nimhdf5
-          nimble -y test
+          nimble -y testCI
 
       #- name: Build docs
       #  if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{matrix.target == 'linux'}}
         run: |
           sudo apt-get update
-          sudo apt-get install pandoc libhdf5-100 libhdf5-dev
+          sudo apt-get install pandoc libhdf5-103 libhdf5-dev
 
       - name: Setup nimble & deps
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         target: [linux] #, macos, windows]
         include:
           - target: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-latest
           #- target: macos
           #  builder: macos-10.15
           #- target: windows

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,12 @@
+* v0.5.3
+- add basic serialization submodule to auto serialize most objects to
+  a H5 file. Scalar types are written as attributes and non scalar as
+  datasets.
+  Can be extended for complicated custom types by using the ~toH5~
+  hook. See the ~tSerialize.nim~ test and the ~serialize.nim~ file.
+  Note: currently no deserialization is supported. You need to parse
+  the data back into your file if needed. An equivalent inverse can be
+  added, but has no priority at the moment.
 * v0.5.2
 - remove support for reading into a ~cstring~, as this is not well
   defined. A local cstring that needs to be created cannot be returned

--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,5 @@
 * v0.5.3
+- *Drops support for Nim 1.4*
 - add basic serialization submodule to auto serialize most objects to
   a H5 file. Scalar types are written as attributes and non scalar as
   datasets.
@@ -7,6 +8,44 @@
   Note: currently no deserialization is supported. You need to parse
   the data back into your file if needed. An equivalent inverse can be
   added, but has no priority at the moment.
+- allow usage of tilde =~= in paths to H5 files
+- replace distinct `hid_t` types by traced 'fat' objects
+
+  The basic idea here is the following:
+  The `hid_t` identifiers all refer to objects that live in the H5
+  library (and possibly in a file). In our previous approach we kept
+  track of different types by using `distinct hid_t` types. That's great
+  because we cannot mix and match the wrong type of identifiers in a
+  given context.
+  However, there are real resources underlying each identifier. Most
+  identifiers require the user to call a `close` / `free` type of
+  routine. While we can associate a destructor with a `=destroy` hook to
+  a `distinct hid_t` (with `hid_t` just being an integer type), the
+  issue is *when* that destructor is being called. In this old way the
+  identifier is a pure value type. If an identifier is copied and the
+  copy goes out of scope early, we release the resource despite still
+  needing it!
+  Therefore, we now have a 'fat' object that knows its internal
+  id (just a real `hid_t`) and which closing function to call. Our
+  actual IDs then are `ref objects` of these fat objects.
+  That way we get sane releasing of resources in the correct moments,
+  i.e. when the last reference to an identifier goes out of scope. This
+  is the correct thing to do in 99% of the cases.
+- add ~FileID~ field to parent file for datasets, similar to already
+  present for groups. Convenient in practice.
+- refactor ~read~ and ~write~ related procs. The meat of the code is
+  now handled in one procedure each (which also takes care of
+  reclaiming VLEN memory for example).
+- greatly improve automatic writing and reading of complex datatypes
+  including Nim objects that contain ~string~ fields or other VLEN
+  data. This is performed by performing a *copy* to a suitable
+  datatype that matches the H5 definition of the equivalent data in
+  Nim.
+  ~type_utils~ and ~copyflat~ submodules are added to that end.
+  In this context there is some trickyness involved, which causes the
+  implementation to be more complex than one might expect. The
+  necessity to get the correct alignment between naive `offsetOf`
+  expectations and the reality of how structs are packed. 
 * v0.5.2
 - remove support for reading into a ~cstring~, as this is not well
   defined. A local cstring that needs to be created cannot be returned

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -10,7 +10,7 @@ skipExt       = @["nim~"]
 
 # Dependencies
 
-requires "nim >= 1.4.0"
+requires "nim >= 1.6.0"
 requires "https://github.com/vindaar/seqmath >= 0.1.17"
 # for blosc support install:
 # requires "nblosc >= 1.15.0"

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -15,7 +15,10 @@ requires "https://github.com/vindaar/seqmath >= 0.1.17"
 # for blosc support install:
 # requires "nblosc >= 1.15.0"
 
-task test, "Runs all tests":
+task testDeps, "Install dependencies for tests":
+  exec "nimble install -y datamancer"
+
+template tests(): untyped {.dirty.} =
   exec "nim c -r tests/tbasic.nim"
   exec "nim c -r tests/tdset.nim"
   exec "nim c -r tests/tread_write1D.nim"
@@ -45,3 +48,12 @@ task test, "Runs all tests":
   if fileExists("dset.h5"): # as a test, we need to get rid of the high level H5 output file
     rmFile("dset.h5")
   exec "nim c -r examples/h5_high_level_example.nim"
+
+task test, "Runs all tests":
+  tests()
+
+task testCI, "Run all tests in CI, including serialization":
+  # For the following we need to add a nimble task to install test dependencies
+  tests()
+  # and the serialization test requiring `datamancer`
+  exec "nim c -r tests/tSerialize.nim"

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -37,6 +37,9 @@ template tests(): untyped {.dirty.} =
   exec "nim c -r tests/tresize_by_add.nim"
   exec "nim c -r tests/tStringAttributes.nim"
   exec "nim c -r tests/tCompound.nim"
+  exec "nim c -r tests/tCompoundWithBool.nim"
+  exec "nim c -r tests/tCompoundWithVlenStr.nim"
+  exec "nim c -r tests/tCompoundWithSeq.nim"
   exec "nim c -r tests/tContainsIterator.nim"
   exec "nim c -r tests/twrite_string.nim"
   # regression tests

--- a/src/nimhdf5.nim
+++ b/src/nimhdf5.nim
@@ -45,3 +45,7 @@ export filters
 
 import nimhdf5/blosc_filter
 export blosc_filter
+
+# serialization
+import nimhdf5 / serialize
+export serialize

--- a/src/nimhdf5/H5nimtypes.nim
+++ b/src/nimhdf5/H5nimtypes.nim
@@ -16,68 +16,9 @@ type
   h5_stat_size_t* = clonglong
   off_t* = h5_stat_size_t
 
-  FileID* = distinct hid_t
-  DatasetID* = distinct hid_t
-  GroupID* = distinct hid_t
-  AttributeID* = distinct hid_t
-  SomeH5ObjectID* = FileID | DatasetID | GroupID | AttributeID
-  DataspaceID* = distinct hid_t
-  DatatypeID* = distinct hid_t
-  MemspaceID* = distinct hid_t
-  HyperslabID* = distinct hid_t # an identifier of a dataspace ID that is a (possibly non contiguous) view
-                                # onto a full dataspace
-
-  FileAccessPropertyListID* = distinct hid_t
-  FileCreatePropertyListID* = distinct hid_t
-  GroupAccessPropertyListID* = distinct hid_t
-  GroupCreatePropertyListID* = distinct hid_t
-  DatasetAccessPropertyListID* = distinct hid_t
-  DatasetCreatePropertyListID* = distinct hid_t
-
 #TODO: need to forbid  `=copy` or else make sure destroy isn' called twice
 # on a dataspace e.g. that was copied!
 # If we figure out a neat solution to this, we could introduce destructors for them.
-
-
-# Since we define hid_t as a distinct type (to deal with the creation of datasets
-# of type `int64` (alias for hid_t before).
-# need to borrow / define comparator etc procs for it
-
-proc `$`*(x: hid_t): string {.borrow.}
-proc `$`*(x: FileID): string {.borrow.}
-proc `$`*(x: DatasetID): string {.borrow.}
-proc `$`*(x: GroupID): string {.borrow.}
-proc `$`*(x: AttributeID): string {.borrow.}
-proc `$`*(x: DataspaceID): string {.borrow.}
-proc `$`*(x: DatatypeID): string {.borrow.}
-proc `$`*(x: MemspaceID): string {.borrow.}
-proc `$`*(x: HyperslabID): string {.borrow.}
-
-proc `$`*(x: FileAccessPropertyListID   ): string {.borrow.}
-proc `$`*(x: FileCreatePropertyListID   ): string {.borrow.}
-proc `$`*(x: GroupAccessPropertyListID  ): string {.borrow.}
-proc `$`*(x: GroupCreatePropertyListID  ): string {.borrow.}
-proc `$`*(x: DatasetAccessPropertyListID): string {.borrow.}
-proc `$`*(x: DatasetCreatePropertyListID): string {.borrow.}
-
-
-## unary minus to write `-1.FileID` etc.
-proc `-`*(x: hid_t): hid_t {.borrow.}
-proc `-`*(x: FileID): FileID {.borrow.}
-proc `-`*(x: DatasetID): DatasetID {.borrow.}
-proc `-`*(x: GroupID): GroupID {.borrow.}
-proc `-`*(x: AttributeID): AttributeID {.borrow.}
-proc `-`*(x: DataspaceID): DataspaceID {.borrow.}
-proc `-`*(x: DatatypeID): DatatypeID {.borrow.}
-proc `-`*(x: MemspaceID): MemspaceID {.borrow.}
-proc `-`*(x: HyperslabID): HyperslabID {.borrow.}
-
-proc `-`*(x: FileAccessPropertyListID   ): FileAccessPropertyListID {.borrow.}
-proc `-`*(x: FileCreatePropertyListID   ): FileCreatePropertyListID {.borrow.}
-proc `-`*(x: GroupAccessPropertyListID  ): GroupAccessPropertyListID {.borrow.}
-proc `-`*(x: GroupCreatePropertyListID  ): GroupCreatePropertyListID {.borrow.}
-proc `-`*(x: DatasetAccessPropertyListID): DatasetAccessPropertyListID {.borrow.}
-proc `-`*(x: DatasetCreatePropertyListID): DatasetCreatePropertyListID {.borrow.}
 
 proc `<`*(x, y: hid_t): bool {.borrow.}
 proc `<`*(x: hid_t, y: int): bool =

--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -104,7 +104,7 @@ proc readAttributeInfo(h5attr: H5Attributes,
 proc readAttributeInfo(h5attr: H5Attributes, key: string) =
   ## reads all information about the attribute `key` from the H5 file
   ## NOTE: this does ``not`` read the value of that attribute!
-  var attr = new H5Attr
+  var attr = newH5Attr()
   attr.attr_id = openAttribute(h5attr, key)
   attr.opened = true
   readAttributeInfo(h5attr, attr, key)
@@ -117,7 +117,7 @@ proc read_all_attributes*(h5attr: H5Attributes) =
   # first get how many objects there are
   h5attr.num_attrs = h5attr.getNumAttrs
   for i in 0 ..< h5attr.num_attrs:
-    var attr = new H5Attr
+    var attr = newH5Attr()
     attr.attr_id = openAttrByIdx(h5attr, i)
     attr.opened = true
     let name = getAttrName(attr.attr_id)

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -1,0 +1,203 @@
+type
+  BufferObj* {.acyclic.} = object
+    size*: int
+    owned*: bool
+    data*: pointer
+    offsetOf*: int
+    children*: seq[Buffer]
+  Buffer* = ref BufferObj
+
+  SimpleTypes* = SomeNumber | char | bool
+
+proc `=destroy`(x: var BufferObj) =
+  for ch in mitems(x.children):
+    `=destroy`(ch)
+  if x.owned and x.data != nil:
+    #echo "deallocing: ", x.offsetOf
+    deallocShared(x.data)
+
+proc `$`*(b: Buffer): string =
+  result = "Buffer(size: " & $b.size & ", owned: " & $b.owned & ", data: " & $b.data.repr & ", offsetOf: " & $b.offsetOf & ", children: " & $b.children.len & ")"
+
+proc newBuffer*(size: int, owned = true): Buffer =
+  result = Buffer(owned: owned, size: size, data: allocShared0(size), offsetOf: 0)
+
+proc newBuffer*(buf: pointer, size: int): Buffer =
+  result = Buffer(owned: false, size: size, data: buf, offsetOf: 0)
+
+proc newBuffer*[T](s: seq[T]): Buffer =
+  result = Buffer(owned: false,
+                  data: (if s.len > 0: cast[pointer](addr(s[0]))
+                         else: nil),
+                  offsetOf: 0)
+
+proc calcSize*[T: object | tuple](x: T): int
+proc calcSize*[T: SimpleTypes](x: T): int =
+  result = sizeof(T)
+
+import typetraits
+proc calcSize*[T: distinct](x: T): int =
+  result = sizeof(distinctBase(T))
+
+proc calcSize*[T: pointer|ptr](x: T): int =
+  result = sizeof(T)
+
+proc calcSize*[T: array](x: T): int =
+  result = sizeof(T)
+
+proc calcSize*[T: string | cstring](x: T): int =
+  result = sizeof(ptr char)
+
+proc calcSize*[T](x: seq[T]): int =
+  result = sizeof(csize_t) + sizeof(pointer)
+
+proc calcSize*[T: object | tuple](x: T): int =
+  for field, val in fieldPairs(x):
+    result += calcSize(val)
+
+proc calcSize*[T](x: typedesc[T]): int =
+  var tmp: T
+  result = calcSize(tmp)
+
+proc `+%`(x: pointer, offset: int): pointer =
+  result = cast[pointer](cast[uint](x) + offset.uint)
+
+proc copyFlat*[T](x: openArray[T]): Buffer
+
+proc copyFlat[T: object | tuple](buf: var Buffer, x: T)
+proc copyFlat[T: SimpleTypes](buf: var Buffer, x: T) =
+  let size = calcSize(x)
+  var target = buf.data +% buf.offsetOf
+  target.copyMem(addr(x), size)
+
+proc copyFlat[T: distinct](buf: var Buffer, x: T) =
+  let size = calcSize(x)
+  var target = buf.data +% buf.offsetOf
+  target.copyMem(addr(x), size)
+
+proc getAddr(x: string): uint =
+  if x.len > 0:
+    result = cast[uint](addr(x[0]))
+  else:
+    result = 0
+
+proc copyFlat[T: string | cstring](buf: var Buffer, x: T) =
+  let size = calcSize(x)
+  var p = getAddr(x) # want to copy the *address* of the string
+  buf.copyFlat(p)
+
+proc copyFlat[T](buf: var Buffer, x: seq[T]) =
+  let child = copyFlat(x)
+  buf.children.add child
+  # copy child address
+  buf.copyFlat((csize_t(x.len), cast[uint](child.data)))
+
+import ./type_utils
+proc copyFlat[T: object | tuple](buf: var Buffer, x: T) =
+  var tmp: genCompatibleTuple(T, replaceVlen = true)
+  #echo "-----------OBJ tuple compat: ", typeName(typeof(tmp)), " OF SIZE: ", sizeof(tmp), " StartingIdx: ", buf.offsetOf, "\n"
+  let startIdx = buf.offsetOf # start data reading here
+  for field, val in fieldPairs(x):
+    buf.offsetOf = startIdx + offsetTup(tmp, field) # new offset
+    buf.copyFlat(val)
+  buf.offsetOf = startIdx + sizeof(tmp) # adjust final offset (jump over last member)
+  #echo "FINAL OFFSET AT PROC END ", buf.offsetOf, " \n=======\n"
+
+proc writeBuffer*(b: Buffer, fname = "/tmp/hexdat.dat") =
+  writeFile(fname, toOpenArray(cast[ptr UncheckedArray[byte]](b.data), 0, b.size-1))
+
+proc copyFlat*[T](x: openArray[T]): Buffer =
+  if x.len > 0:
+    let size = x.len * calcSize(x[0])
+    result = newBuffer(size)
+    when T.needsCopy:
+      var tmp: genCompatibleTuple(T, replaceVlen = true)
+    else:
+      var tmp: T
+    for el in x:
+      result.copyFlat(el)
+      when typeof(tmp) isnot tuple|object: # in the other case incrementation is done in the `copyFlat` proc above
+        inc result.offsetOf, sizeof(tmp)
+  else:
+    result = newBuffer(0)
+
+proc fromFlat*[T](buf: Buffer): seq[T]
+proc fromFlat[T: SimpleTypes | pointer](x: var T, buf: Buffer) =
+  let size = calcSize(x)
+  var source = buf.data +% buf.offsetOf
+  copyMem(addr(x), source, size)
+
+## XXX: `fromFlat` for fixed length arrays!
+proc fromFlat*[T: array](x: var T, buf: Buffer) =
+  let size = calcSize(x)
+  var source = buf.data +% buf.offsetOf
+  copyMem(addr(x), source, size)
+
+proc fromFlat[T: string | cstring](x: var T, buf: Buffer) =
+  let source = buf.data +% buf.offsetOf
+  let strBuf = cast[ptr cstring](source)
+  if not strBuf.isNil:
+    when T is string:
+      x = $(strBuf[])
+    else:
+      x = strBuf[]
+
+proc fromFlat[T](x: var seq[T], buf: Buffer) =
+  # construct a child buffer.
+  # 1. extract the size of the child buffer
+  var len: csize_t
+  len.fromFlat(buf)
+  inc buf.offsetOf, sizeof(csize_t)
+  let source = buf.data +% buf.offsetOf
+  # 2. extract the data pointer
+  var p: pointer
+  p.fromFlat(buf)
+  let bufChild = newBuffer(p, len.int * calcSize(T))
+  x = fromFlat[T](bufChild)
+  inc buf.offsetOf, sizeof(pointer)
+
+proc fromFlat[T: object | tuple](x: var T, buf: Buffer) =
+  var tmp: genCompatibleTuple(T, replaceVlen = true)
+  #echo "-----------OBJ tuple compat: ", typeName(typeof(tmp)), " OF SIZE: ", sizeof(tmp), " StartingIdx: ", buf.offsetOf, "\n"
+  let startIdx = buf.offsetOf
+  for field, val in fieldPairs(x):
+    buf.offsetOf = startIdx + offsetTup(tmp, field)
+    val.fromFlat(buf)
+  buf.offsetOf = startIdx + sizeof(tmp)
+  #echo "FINAL OFFSET AT PROC END ", buf.offsetOf, " \n=======\n"
+
+proc fromFlat*[T](buf: Buffer): seq[T] =
+  ## Returns a sequence of `T` from the given buffer, taking into account conversion from
+  ## `ptr char` to `string` and nested buffer children to `seq[U]`.
+  let len = buf.size div calcSize(T)
+  # set `offsetOf` to 0 to copy from beginning
+  buf.offsetOf = 0
+  result = newSeq[T](len)
+  when T.needsCopy:
+    var tmp: genCompatibleTuple(T, replaceVlen = true)
+  else:
+    var tmp: T
+  for i in 0 ..< result.len:
+    # copy element by element
+    result[i].fromFlat(buf)
+    when typeof(tmp) isnot tuple|object: # in the other case incrementation is done in the `copyFlat` proc above
+      inc buf.offsetOf, sizeof(tmp)
+
+when isMainModule:
+  block A:
+    var data = newSeq[(int, (float, string), seq[string])]()
+    data.add (0xAFFEAFFE.int, (2342.2, "hello"), @["A", "HALO"])
+    #buf.add (0x13371337.int, ("", 52.2), @["B", "FOO"])
+    let buf = copyFlat(data)
+
+    let xx = fromFlat[(int, (float, string), seq[string])](buf)
+    echo xx
+
+  block B:
+    var data = newSeq[(int, (float, string), seq[int])]()
+    data.add (0xAFFEAFFE.int, (2342.2, "hello"), @[1, 2, 3, 4, 5])
+    #data.add (0x13371337.int, ("", 52.2), @["B", "FOO"])
+    let buf = copyFlat(data)
+
+    let xx = fromFlat[(int, (float, string), seq[int])](buf)
+    echo xx

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -1,3 +1,5 @@
+from util import address
+
 type
   BufferObj* {.acyclic.} = object
     size*: int
@@ -27,7 +29,7 @@ proc newBuffer*(buf: pointer, size: int): Buffer =
 
 proc newBuffer*[T](s: seq[T]): Buffer =
   result = Buffer(owned: false,
-                  data: (if s.len > 0: cast[pointer](addr(s[0]))
+                  data: (if s.len > 0: cast[pointer](address(s[0]))
                          else: nil),
                   offsetOf: 0)
 
@@ -68,25 +70,18 @@ proc copyFlat[T: object | tuple](buf: var Buffer, x: T)
 proc copyFlat[T: SimpleTypes](buf: var Buffer, x: T) =
   let size = calcSize(x)
   var target = buf.data +% buf.offsetOf
-  target.copyMem(addr(x), size)
+  target.copyMem(address(x), size)
 
 proc copyFlat[T: distinct](buf: var Buffer, x: T) =
   let size = calcSize(x)
   var target = buf.data +% buf.offsetOf
-  target.copyMem(addr(x), size)
+  target.copyMem(address(x), size)
 
-when (NimMajor, NimMinor, NimPatch) < (1, 9, 0):
-  proc getAddr(x: string): uint =
-    if x.len > 0:
-      result = cast[uint](unsafeAddr(x[0]))
-    else:
-      result = 0
-else:
-  proc getAddr(x: string): uint =
-    if x.len > 0:
-      result = cast[uint](addr(x[0]))
-    else:
-      result = 0
+proc getAddr(x: string): uint =
+  if x.len > 0:
+    result = cast[uint](address(x[0]))
+  else:
+    result = 0
 
 proc copyFlat[T: string | cstring](buf: var Buffer, x: T) =
   let size = calcSize(x)

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -75,11 +75,18 @@ proc copyFlat[T: distinct](buf: var Buffer, x: T) =
   var target = buf.data +% buf.offsetOf
   target.copyMem(addr(x), size)
 
-proc getAddr(x: string): uint =
-  if x.len > 0:
-    result = cast[uint](addr(x[0]))
-  else:
-    result = 0
+when (NimMajor, NimMinor, NimPatch) < (1, 9, 0):
+  proc getAddr(x: string): uint =
+    if x.len > 0:
+      result = cast[uint](unsafeAddr(x[0]))
+    else:
+      result = 0
+else:
+  proc getAddr(x: string): uint =
+    if x.len > 0:
+      result = cast[uint](addr(x[0]))
+    else:
+      result = 0
 
 proc copyFlat[T: string | cstring](buf: var Buffer, x: T) =
   let size = calcSize(x)

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -718,7 +718,7 @@ proc prepareData[T](data: openArray[T] | seq[T], dset: H5Dataset,
       # only copy as many bytes as either in input string to write or
       # as we have space in the allocated fixed length dataset
       let copyLen = min(size.int,  el.len)
-      when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
+      when (NimMajor, NimMinor, NimPatch) >= (1, 7, 0):
         copyMem(result[i * size.int].addr, el[0].addr, copyLen)
       else:
         copyMem(result[i * size.int].addr, el[0].unsafeAddr, copyLen)

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -1167,7 +1167,7 @@ proc `[]`*[T](dset: H5DataSet, ind: int, t: typedesc[T]): T =
   # return element of bufer
   result = buf[0]
 
-proc `[]`*[T](dset: H5DataSet, indices: seq[int], t: typedesc[T]): seq[T] =
+proc read*[T](dset: H5DataSet, indices: seq[int], t: typedesc[T]): seq[T] =
   ## Same as above proc, but reads several indices at once
   ## inputs:
   ##   dset: var H5DataSet = the dataset from which to read an element
@@ -1193,9 +1193,25 @@ proc `[]`*[T](dset: H5DataSet, indices: seq[int], t: typedesc[T]): seq[T] =
   # return element of bufer
   result = buf
 
+proc `[]`*[T](h5f: H5File, name: string, dtype: typedesc[T]): seq[T] =
+  ## reads data from the H5file without an intermediate return of a `H5DataSet`
+  result = h5f.get(name.dset_str).read(dtype)
+
+proc `[]`*[T](dset: H5DataSet, indices: seq[int], t: typedesc[T]): seq[T] =
+  ## convenience overload for `dset.read(indices, t)`
+  dset.read(indices, t)
+
 proc `[]`*[T](dset: H5DataSet, indices: seq[int], t: DatatypeID, dtype: typedesc[T]): seq[seq[T]] =
   ## reads a single or several elements from a variable length dataset
   result = read(dset, t, dtype, indices)
+
+proc `[]`*[T](h5f: H5File, name: string, indices: seq[int], dtype: typedesc[T]): seq[T] =
+  ## reads a single or several elements from a dataset
+  result = h5f.get(name.dset_str).read(indices, dtype)
+
+proc `[]`*[T](h5f: H5File, name: string, indices: seq[int], t: DatatypeID, dtype: typedesc[T]): seq[seq[T]] =
+  ## reads a single or several elements from a variable length dataset
+  result = h5f.get(name.dset_str).read(t, dtype, indices)
 
 proc `[]`*[T](dset: H5DataSet, t: DatatypeID, dtype: typedesc[T], indices: seq[int]): seq[seq[T]]
   {.deprecated: "This proc is deprecated! Use the version with `indices` as the second argument!".} =
@@ -1214,10 +1230,6 @@ proc `[]`*[T](dset: H5DataSet, t: DatatypeID, dtype: typedesc[T], idx: int): seq
 proc `[]`*[T](dset: H5DataSet, t: DatatypeID, dtype: typedesc[T]): seq[seq[T]] =
   ## reads a whole variable length dataset, wrapper around `read`
   result = read(dset, t, dtype)
-
-proc `[]`*[T](h5f: H5File, name: string, dtype: typedesc[T]): seq[T] =
-  ## reads data from the H5file without an intermediate return of a `H5DataSet`
-  result = h5f.get(name.dset_str).read(dtype)
 
 proc `[]`*[T](h5f: H5File, name: string, t: DatatypeID, dtype: typedesc[T]):
                 seq[seq[T]] =

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -770,7 +770,7 @@ proc writeImpl[T](dset: H5Dataset, data: seq[T] | openArray[T] | ptr T,
                        hyperslabId)
     else:
       result = writeH5(dset,
-                       addr(buf[0]),
+                       address(buf[0]),
                        memspaceId,
                        hyperslabId)
 
@@ -1108,7 +1108,7 @@ proc select_elements[T](dset: H5DataSet, coord: seq[T]): DataspaceID {.inline, d
   let res = H5Sselect_elements(result.id,
                                H5S_SELECT_SET,
                                csize_t(coord.len),
-                               addr(flat_coord[0]))
+                               address(flat_coord[0]))
   if res < 0:
     raise newException(HDF5LibraryError, "Call to HDF5 library failed in `select_elements` " &
       "after a call to `H5Sselect_elements` with return code " & $res)
@@ -1654,7 +1654,7 @@ proc resize*[T: tuple | seq](dset: H5DataSet, shape: T) =
     # be closed until we leave this scope (via `=destroy`)
     # (dataspace_id is a proc!)
     let dspace = dset.dataspace_id
-    let status = H5Dset_extent(dset.dataset_id.id, addr(newshape[0]))
+    let status = H5Dset_extent(dset.dataset_id.id, address(newshape[0]))
     # set the shape we just resized to as the current shape
     withDebug:
       echo "Extending the dataspace to ", newshape

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -617,6 +617,7 @@ proc create_dataset*[T: (tuple | int | seq)](
   # set up the dataset object
   let file_ref = h5f.getFileRef()
   result = newH5DataSet(dsetName, file_ref.name,
+                        file_ref.file_id,
                         parent = group.name,
                         parentId = parentId,
                         shape = shape_seq)

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -407,7 +407,7 @@ proc parseShapeTuple[T: tuple](dims: T): seq[int] =
     result.add int(el)
 
 proc parseChunkSizeAndMaxShape(dset: H5DataSet, chunksize, maxshape: seq[int],
-                               filter: H5Filter, autoChunkIfFilter: bool): hid_t =
+                               filter: H5Filter, autoChunkIfFilter: bool): herr_t =
   ## proc to parse the chunk size and maxhshape arguments handed to the create_dataset()
   ## Takes into account the different possible scenarios:
   ##    chunksize: seq[int] = a sequence containing the chunksize: the dataset should be
@@ -451,7 +451,7 @@ proc parseChunkSizeAndMaxShape(dset: H5DataSet, chunksize, maxshape: seq[int],
     # if neither given, maxshape will be current shape
     # and return 0
     dset.maxshape = dset.shape
-    result = 0.hid_t
+    result = 0.herr_t
   # handle case where maxshape.len == 0 while chunksize.len > 0
   # issue #17
   elif chunksize.len > 0 and maxshape.len == 0:

--- a/src/nimhdf5/dataspaces.nim
+++ b/src/nimhdf5/dataspaces.nim
@@ -20,12 +20,12 @@ import H5nimtypes
 import util
 import datatypes
 
-proc set_chunk*(papl_id: DatasetCreatePropertyListID, chunksize: seq[int]): hid_t =
+proc set_chunk*(papl_id: DatasetCreatePropertyListID, chunksize: seq[int]): herr_t =
   ## proc to set chunksize of the given object, should be a dataset,
   ## but we do not perform checks!
   var mchunksize = mapIt(chunksize, hsize_t(it))
   # convert return value of H5Pset_chunk to `hid_t`, because H5 wrapper returns `herr_t`
-  result = H5Pset_chunk(papl_id.hid_t, cint(len(mchunksize)), addr(mchunksize[0])).hid_t
+  result = H5Pset_chunk(papl_id.id, cint(len(mchunksize)), addr(mchunksize[0])).herr_t
 
 proc parseMaxShape(maxshape: seq[int]): seq[hsize_t] =
   ## this proc parses the maxshape given to simple_dataspace by taking into

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -345,6 +345,10 @@ proc newH5Id(x: hid_t, kind: CloseKind): H5Id =
   result = H5Id(id: x, kind: kind)
 
 template genHelpers(typ: untyped, k: untyped): untyped =
+  ## in 1.6 still we cannot define a `ref type` destructor. There is some bug on devel *without this*
+  ## that causes invalid `free()` calls :(
+  when (NimMajor, NimMinor, NimPatch) > (1, 7, 0):
+    proc `=destroy`*(x: typ) = `=destroy`(cast[H5Id](x))
   proc `new typ`*(x: hid_t): typ =
     result = typ(newH5Id(x, k))
 

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -126,6 +126,7 @@ type
     parent_id*: ParentID
     # filename string, in which the dataset is located
     file*: string
+    file_id*: FileId
     # reference to the file object, in which dataset resides. Important to perform checks
     # in procs, which should not depend explicitly on H5File, but necessarily depend
     # implicitly on it, e.g. create_dataset (called from group) etc.

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -345,17 +345,12 @@ proc newH5Id(x: hid_t, kind: CloseKind): H5Id =
   result = H5Id(id: x, kind: kind)
 
 template genHelpers(typ: untyped, k: untyped): untyped =
-  ## in 1.6 still we cannot define a `ref type` destructor. There is some bug on devel *without this*
-  ## that causes invalid `free()` calls :(
-  when (NimMajor, NimMinor, NimPatch) > (1, 7, 0):
-    proc `=destroy`*(x: typ) = `=destroy`(cast[H5Id](x))
   proc `new typ`*(x: hid_t): typ =
     result = typ(newH5Id(x, k))
 
   proc close*(x: typ, msg = "") = distinctBase(x).close(msg)
   template `to typ`*(x: hid_t): typ = `new typ`(x)
   template id*(x: typ): hid_t = distinctBase(x).id
-  #converter toInt*(x: `typ Obj`): int = x.hid_t.int
   proc `$`*(x: typ): string = $typ & "(" & $id(x).int & ")"
 
 

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -352,7 +352,7 @@ template genHelpers(typ: untyped, k: untyped): untyped =
   template `to typ`*(x: hid_t): typ = `new typ`(x)
   template id*(x: typ): hid_t = distinctBase(x).id
   #converter toInt*(x: `typ Obj`): int = x.hid_t.int
-  converter toInt*(x: typ): int = distinctBase(x).id.int
+  proc `$`*(x: typ): string = $typ & "(" & $id(x).int & ")"
 
 
 genHelpers(FileID, ckFile)

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -410,7 +410,7 @@ proc close*(dtype_id: DatatypeID) =
 
 proc close*(attr: var H5AttrObj) =
   ## closes the attribute and the corresponding dataspace
-  if attr.opened and attr.attr_id.hid_t.isObjectOpen:
+  if attr.isObjectOpen():
     var err = H5Sclose(attr.attr_dspace_id.hid_t)
     if err < 0:
       raise newException(HDF5LibraryError, "Error closing dataspace of attribute with id" &
@@ -438,7 +438,7 @@ proc flush*(group: H5Group, flushKind: FlushKind) =
       " as " & $flushKind & " failed!")
 
 proc close*(group: var H5GroupObj) =
-  if group.opened and group.isObjectOpen():
+  if group.isObjectOpen():
     let err = H5Gclose(group.group_id.hid_t)
     if err != 0:
       raise newException(HDF5LibraryError, "Failed to close group " & group.name & "!")
@@ -461,7 +461,7 @@ proc flush*(dset: H5DataSetObj, flushKind: FlushKind) =
 proc flush*(dset: H5DataSet, flushKind: FlushKind) = dset[].flush(flushKind)
 
 proc close*(dset: var H5DataSetObj) =
-  if dset.opened and dset.isObjectOpen():
+  if dset.isObjectOpen():
     # close the dataset creation property list, important if filters are used
     dset.dcpl_id.close(msg = "dcpl associated with dataset: " & $dset.name)
     withDebug:

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -411,16 +411,16 @@ proc close*(dtype_id: DatatypeID) =
 proc close*(attr: var H5AttrObj) =
   ## closes the attribute and the corresponding dataspace
   if attr.opened and attr.attr_id.hid_t.isObjectOpen:
-    var err = H5Aclose(attr.attr_id.hid_t)
+    var err = H5Sclose(attr.attr_dspace_id.hid_t)
+    if err < 0:
+      raise newException(HDF5LibraryError, "Error closing dataspace of attribute with id" &
+        $(attr.attr_id.hid_t) & "!")
+    err = H5Aclose(attr.attr_id.hid_t)
     if err < 0:
       raise newException(HDF5LibraryError, "Error closing attribute with id " &
         $(attr.attr_id.hid_t) & "!")
     withDebug:
       echo "Closed attribute with status ", err
-    err = H5Sclose(attr.attr_dspace_id.hid_t)
-    if err < 0:
-      raise newException(HDF5LibraryError, "Error closing dataspace of attribute with id" &
-        $(attr.attr_id.hid_t) & "!")
     attr.opened = false
 
 proc close*(attr: H5Attr) = attr[].close()

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -302,7 +302,7 @@ proc to_hid_t*(p: ParentID): hid_t =
     raise newException(ValueError, "Cannot convert ParentID of kind " & $p.kind &
       " to a `hid_t` value.")
 
-func getH5Id*[T: H5File | H5DataSet | H5DatasetObj | H5Group | H5GroupObj](h5o: T): ParentID =
+func getH5Id*[T: H5File | H5DataSet | H5DatasetObj | H5Group | H5GroupObj | H5Attr | H5AttrObj](h5o: T): ParentID =
   ## this func returns the ID of the given object as a `ParentID`
   ## of the correct kind.
   when h5o is H5File:
@@ -311,6 +311,8 @@ func getH5Id*[T: H5File | H5DataSet | H5DatasetObj | H5Group | H5GroupObj](h5o: 
     result = ParentID(kind: okGroup, gid: h5o.group_id)
   elif h5o is H5DataSet or h5o is H5DatasetObj:
     result = ParentID(kind: okDataset, did: h5o.dataset_id)
+  elif h5o is H5AttrObj or h5o is H5Attr:
+    result = ParentID(kind: okAttr, attrId: h5o.attr_id)
   else:
     {.error: "Invalid branch!".}
 

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -1,7 +1,8 @@
 import std / [strutils, tables, strformat, macros, typetraits]
 
 import hdf5_wrapper, H5nimtypes, util
-from type_utils import needsCopy, genCompatibleTuple
+from type_utils import needsCopy, genCompatibleTuple, offsetStr, offsetTup, typeName
+
 
 # add an invalid rw code to handle wrong inputs in parseH5rw_type
 const H5F_INVALID_RW* = cuint(0x00FF)

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -703,6 +703,7 @@ proc initH5Attributes*(p_id: sink ParentID, p_name: string = "", p_type: string 
   # read_all_attributes(h5attr)
   result = h5attr
 
+proc newH5Attr*(): H5Attr = H5Attr(opened: false)
 proc newH5DataSet*(name: string = "",
                    file: string = "",
                    file_id: FileID = -1.hid_t.toFileId(),

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -905,8 +905,11 @@ proc nimToH5type*(dtype: typedesc, variableString = false): DatatypeID =
   elif dtype is seq:
     res = special_type(getInnerType(dtype)).hid_t ## NOTE: back conversion to hid_t
   elif dtype is bool:
-    ## XXX: handle bool!
-    raise newException(ValueError, "Boolean types cannot be stored in HDF5 yet.")
+    when sizeof(bool) == 1:
+      res = H5T_NATIVE_UCHAR
+    else:
+      ## XXX: handle bool IN OTHER CASES
+      raise newException(ValueError, "Boolean types cannot be stored in HDF5 yet unless it is of size 1 byte.")
   elif dtype is distinct:
     return nimToH5Type(distinctBase(dtype), variableString)
   else:

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -1,6 +1,6 @@
 # stdlib
 import std / [tables, strutils]
-from os import fileExists
+from os import fileExists, expandTilde
 # internal
 import hdf5_wrapper, H5nimtypes, datatypes, h5util, util
 from datasets import `[]`
@@ -74,6 +74,7 @@ proc H5open*(name, rwType: string, accessFlags: set[AccessKind] = {}): H5File =
   ##            for the C functions
   ## throws:
   ##     IOError: in case file is opened without write access, but does not exist
+  let name = name.expandTilde()
   # create a new H5File object with default settings (i.e. no opened file etc)
   result = newH5File()
   # set the name of the file to be accessed

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -231,6 +231,8 @@ proc close*(h5f: H5File): herr_t =
     h5f.printOpenObjects()
     # should be zero now
     echo "Still open objects are ", objsYet
+    for obj in objsYet:
+      echo getName(obj)
 
   if h5f.isObjectOpen: # close file only if still open
     # flush the file

--- a/src/nimhdf5/filters.nim
+++ b/src/nimhdf5/filters.nim
@@ -67,12 +67,12 @@ proc setFilters*(dset: H5DataSet, filter: H5Filter) =
     if filter.pixPerBlock.uint8 notin SzipPixPerBlockSet:
       raise newException(ValueError, "Invalid `pixPerBlock` value for SZip " &
         "compression. Valid values are even, positive integers <= 32")
-    status = H5Pset_szip(dset.dcpl_id.hid_t, filter.optionMask.cuint, filter.pixPerBlock.cuint)
+    status = H5Pset_szip(dset.dcpl_id.id, filter.optionMask.cuint, filter.pixPerBlock.cuint)
   of fkZlib:
     if filter.zlibLevel notin ZlibCompressionLevel:
       raise newException(ValueError, "Invalid `zlibLevel` compression value Zlib " &
         "compression. Valid values are {0 .. 9}")
-    status = H5Pset_deflate(dset.dcpl_id.hid_t, filter.zlibLevel.cuint)
+    status = H5Pset_deflate(dset.dcpl_id.id, filter.zlibLevel.cuint)
   of fkBlosc:
     # TODO: only
     when HasBloscSupport:
@@ -81,7 +81,7 @@ proc setFilters*(dset: H5DataSet, filter: H5Filter) =
       filterVals[5] = if filter.doShuffle: 1 else: 0
       filterVals[6] = filter.compressor.cuint
       # set the filter
-      status = H5Pset_filter(dset.dcpl_id.hid_t, FILTER_BLOSC, H5Z_FLAG_OPTIONAL,
+      status = H5Pset_filter(dset.dcpl_id.id, FILTER_BLOSC, H5Z_FLAG_OPTIONAL,
                              filterVals.len.csize_t, addr filterVals[0])
     else:
       raise newException(NotImplementedError, "Blosc support not available, due " &

--- a/src/nimhdf5/groups.nim
+++ b/src/nimhdf5/groups.nim
@@ -58,8 +58,8 @@ proc openGroup*(h5f: H5File, group: string): GroupID =
     # return id from table
     result = h5f.groups[group].group_id
   elif group in h5f: # exists, but not open. `file_id` is the relevant location id
-    result = H5Gopen2(h5f.file_id.hid_t, group.cstring, H5P_DEFAULT).GroupID
-    if result.hid_t < 0:
+    result = H5Gopen2(h5f.file_id.id, group.cstring, H5P_DEFAULT).toGroupID
+    if result.id < 0:
       raise newException(HDF5LibraryError, "call to H5 library failed in " &
         "`createGroupFromParent` trying to open group via `H5Gopen2`!")
     withDebug:
@@ -79,8 +79,8 @@ proc createGroupImpl*(h5f: H5File, group: string): GroupID =
     else:
       debugEcho "Calling `createGroup` despite ", group, " existing in file!"
   # group non existant, `file_id` is the relevant location id
-  result = H5Gcreate2(h5f.file_id.hid_t, group, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT).GroupID
-  if result.hid_t < 0:
+  result = H5Gcreate2(h5f.file_id.id, group, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT).toGroupID
+  if result.id < 0:
     raise newException(HDF5LibraryError, "call to H5 library failed in " &
       "`createGroupFromParent` trying to create group via `H5Gcreate2`!")
 

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -489,11 +489,11 @@ proc copy*[T](h5in: H5File, h5o: T,
   if target.isSome:
     tgt = target.get
 
-  var targetGrp = if target.isSome: target.get.parentDir: else: "/"
+  var targetGrp = if target.isSome: target.get.parentDir else: "/"
   if targetGrp.len == 0:
     targetGrp = "/"
   var targetName = if target.isSome:
-                     target.get.extractFileName:
+                     target.get.extractFileName
                    else:
                      h5o.name
 

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -316,6 +316,7 @@ proc getNumberOpenObject*(h5id: FileID, objectKinds: set[ObjectKind]): int =
   let err = H5Fget_obj_count(h5id.hid_t, objectKinds.toH5())
   if err < 0:
     raise newException(HDF5LibraryError, "Call to `H5get_obj_count` failed in `getNumberOpenObjects`.")
+  result = err.int
 
 proc getOpenObjectIds*(h5id: FileID, objectKinds: set[ObjectKind]): seq[hid_t] =
   ## Return all IDs of objects of `kind` that are still open in the file.

--- a/src/nimhdf5/pretty_printing.nim
+++ b/src/nimhdf5/pretty_printing.nim
@@ -7,10 +7,10 @@ proc pretty*(att: H5Attr, indent = 0, full = false): string =
   result.add &"{fieldInd}opened: {att.opened},\n"
   result.add &"{fieldInd}dtypeAnyKind: {att.dtypeAnyKind}"
   if full:
-    result.add &",\n{fieldInd}attr_id: {att.attr_id.hid_t},\n"
-    result.add &"{fieldInd}dtype_c: {att.dtype_c.hid_t},\n"
+    result.add &",\n{fieldInd}attr_id: {att.attr_id.id},\n"
+    result.add &"{fieldInd}dtype_c: {att.dtype_c.id},\n"
     result.add &"{fieldInd}dtypeBaseKind: {att.dtypeBaseKind},\n"
-    result.add &"{fieldInd}attr_dspace_id: {att.attr_dspace_id.hid_t}"
+    result.add &"{fieldInd}attr_dspace_id: {att.attr_dspace_id.id}"
   result.add repeat(' ', indent) & "\n}"
 
 proc `$`*(att: H5Attr): string =
@@ -52,12 +52,12 @@ proc pretty*(dset: H5DataSet, indent = 0, full = false): string =
     result.add &"{fieldInd}chunksize: {dset.chunksize},\n"
     result.add &"{fieldInd}dtypeAnyKind: {dset.dtypeAnyKind},\n"
     result.add &"{fieldInd}dtypeBaseKind: {dset.dtypeBaseKind},\n"
-    result.add &"{fieldInd}dtype_c: {dset.dtype_c.hid_t},\n"
+    result.add &"{fieldInd}dtype_c: {dset.dtype_c.id},\n"
     result.add &"{fieldInd}dtype_class: {dset.dtype_class},\n"
-    result.add &"{fieldInd}dataset_id: {dset.dataset_id.hid_t},\n"
+    result.add &"{fieldInd}dataset_id: {dset.dataset_id.id},\n"
     result.add &"{fieldInd}num_attrs: {dset.attrs.num_attrs},\n"
-    result.add &"{fieldInd}dapl_id: {dset.dapl_id.hid_t},\n"
-    result.add &"{fieldInd}dcpl_id: {dset.dcpl_id.hid_t}"
+    result.add &"{fieldInd}dapl_id: {dset.dapl_id.id},\n"
+    result.add &"{fieldInd}dcpl_id: {dset.dcpl_id.id}"
   result.add &"\n" & repeat(' ', indent) & "}"
 
 proc `$`*(dset: H5DataSet): string =
@@ -73,11 +73,11 @@ proc pretty*(grp: H5Group, indent = 2, full = false): string =
   result.add &"{fieldInd}file: {grp.file},\n"
   result.add &"{fieldInd}parent: {grp.parent}"
   if full:
-    result.add &",\n{fieldInd}file_id: {grp.file_id.hid_t},\n"
-    result.add &"{fieldInd}group_id: {grp.group_id.hid_t},\n"
+    result.add &",\n{fieldInd}file_id: {grp.file_id.id},\n"
+    result.add &"{fieldInd}group_id: {grp.group_id.id},\n"
     result.add &"{fieldInd}parent_id: {grp.parent_id.kind}, {grp.parent_id.to_hid_t},\n"
-    result.add &"{fieldInd}gapl_id: {grp.gapl_id.hid_t},\n"
-    result.add &"{fieldInd}gcpl_id: {grp.gcpl_id.hid_t}"
+    result.add &"{fieldInd}gapl_id: {grp.gapl_id.id},\n"
+    result.add &"{fieldInd}gcpl_id: {grp.gcpl_id.id}"
   # datasets
 
   if grp.datasets.len > 0:
@@ -117,7 +117,7 @@ proc pretty*(h5f: H5File, indent = 2, full = false): string =
   result.add &"{fieldInd}accessFlags: {h5f.accessFlags},\n"
   result.add &"{fieldInd}visited: {h5f.visited}"
   if full:
-    result.add &",\n{fieldInd}nfile_id: {h5f.file_id.hid_t},\n"
+    result.add &",\n{fieldInd}nfile_id: {h5f.file_id.id},\n"
     result.add &"{fieldInd}err: {h5f.err},\n"
     result.add &"{fieldInd}status: {h5f.status}"
   if h5f.datasets.len > 0:

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -92,3 +92,12 @@ proc toH5*[T](x: T,
   let err = h5f.close()
   if err != 0:
     raise newException(IOError, "Failed to close the H5 file " & $file & " after writing.")
+
+import std / options
+proc toH5*[T](h5f: H5File, x: Option[T], name = "", path = "/") =
+  ## Option is simply written as a regular object if it is `some`, else it is
+  ## ignored.
+  ## XXX: Of course when parsing we need to check and do the same.
+  ## XXX: add some field (attribute?) indicating it's an option?
+  if x.isSome:
+    h5f.toH5(x.get, name, path)

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -70,11 +70,13 @@ proc toH5*[T: seq](h5f: H5File, x: T, name = "", path = "/") =
       $x.shape & " and type " & $T)
 
 proc toH5*[T: object](h5f: H5File, x: T, name = "", path = "/") =
+  ## XXX: In principle we could have a check / option that allows to
+  ## store fully flat `objects` as a composite type (via the already
+  ## supported functionality).
   # construct group of the name under `path`
-  let grp = path / name / $typeof(T)
+  let grp = path / name
   discard h5f.create_group(grp)
   for field, val in fieldPairs(x):
-    echo "Field: ", field
     h5f.toH5(val, field, grp)
 
 proc toH5*[T: ref object](h5f: H5File, x: T, name = "", path = "/") =

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -46,7 +46,7 @@ proc toH5*[T: seq](h5f: H5File, x: T, name = "", path = "/") =
     dset[dset.all] = x
   else:
     raise newException(ValueError, "For now cannot serialize a nested sequence. Argument of shape " &
-      x.shape & " and type " & $T)
+      $x.shape & " and type " & $T)
 
 proc toH5*[T: object](h5f: H5File, x: T, name = "", path = "/") =
   # construct group of the name under `path`

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -202,7 +202,10 @@ proc fromH5*[N; T](h5f: H5File, res: var array[N, T], name = "", path = "/") =
       let data = h5f[path / name, T]
       doAssert res.len == data.len
       for i, x in data:
-        res[i] = x
+        when N is SomeInteger:
+          res[i] = x
+        else:
+          res[N(i)] = x
     elif T is enum:
       let data = h5f[path / name, string]
       doAssert res.len == data.len

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -62,9 +62,9 @@ proc toH5*[T: ref object](h5f: H5File, x: T, name = "", path = "/") =
   h5f.toH5(x[], name, path)
 
 proc toH5*[T](x: T,
-             file: string,
-             path: string = "/") = # group in the file (to add to an existing file for example
-  var h5f = H5File(file, "rw")
+              file: string,
+              path: string = "/") = # group in the file (to add to an existing file for example
+  var h5f = H5open(file, "rw")
   h5f.toH5(x, path)
   let err = h5f.close()
   if err != 0:

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -1,0 +1,71 @@
+#[
+This file contains helpers to serialize objects to a H5 file.
+
+]#
+
+from std / typetraits import distinctBase
+from os import `/`
+import ./datatypes, ./datasets, ./files, ./groups, ./util
+
+
+proc toH5*[T: distinct](h5f: H5File, x: T, name = "", path = "/") =
+  ## A single number is stored as an attribute with `name` under `path`.
+  ## An additional attribute is created that stores the name of the original type.
+  let xD = distinctBase(T)(x)
+  h5f.toH5(xD, name, path)
+  let obj = h5f[path.grp_str]
+  obj.attrs["typeof(" & name & ")"] = $T
+
+proc toH5*[T: SomeNumber](h5f: H5File, x: T, name = "", path = "/") =
+  ## A single number is stored as an attribute with `name` under `path`
+  let obj = h5f[path.grp_str]
+  obj.attrs[name] = x
+
+proc toH5*[T: char | string | cstring](h5f: H5File, x: T, name = "", path = "/") =
+  ## A single character is stored as an attribute with `name` under `path`
+  let obj = h5f[path.grp_str]
+  obj.attrs[name] = x
+
+proc toH5*[T: enum](h5f: H5File, x: T, name = "", path = "/") =
+  ## An enum is stored as an attribute with `name` under `path` where the
+  ## value is written as the *string value* of that attribute.
+  let obj = h5f[path.grp_str]
+  obj.attrs[name] = $x
+
+proc toH5*[T: seq](h5f: H5File, x: T, name = "", path = "/") =
+  ## A sequence is stored as a 1D dataset if it is a flat sequence, else we
+  ## raise an exception.
+  ##
+  ## XXX: We could check manually if the sequence can be flattened (all sub elements
+  ## same length) or just default to assume it is not flat and store as variable length.
+  ## But what to do for 3D, 4D etc?
+  when getInnerType(x) is SomeNumber | char | string | cstring:
+    let dset = h5f.create_dataset(path / name,
+                                  x.len, # 1D, so use length
+                                  getInnerType(x))
+    dset[dset.all] = x
+  else:
+    raise newException(ValueError, "For now cannot serialize a nested sequence. Argument of shape " &
+      x.shape & " and type " & $T)
+
+proc toH5*[T: object](h5f: H5File, x: T, name = "", path = "/") =
+  # construct group of the name under `path`
+  let grp = path / name / $typeof(T)
+  discard h5f.create_group(grp)
+  for field, val in fieldPairs(x):
+    echo "Field: ", field
+    h5f.toH5(val, field, grp)
+
+proc toH5*[T: ref object](h5f: H5File, x: T, name = "", path = "/") =
+  ## Ref objects are dereferenced and the underlying object stored. Be careful with
+  ## nested reference objects that might by cyclic!
+  h5f.toH5(x[], name, path)
+
+proc toH5*[T](x: T,
+             file: string,
+             path: string = "/") = # group in the file (to add to an existing file for example
+  var h5f = H5File(file, "rw")
+  h5f.toH5(x, path)
+  let err = h5f.close()
+  if err != 0:
+    raise newException(IOError, "Failed to close the H5 file " & $file & " after writing.")

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -32,6 +32,13 @@ proc toH5*[T: enum](h5f: H5File, x: T, name = "", path = "/") =
   let obj = h5f[path.grp_str]
   obj.attrs[name] = $x
 
+proc toH5*[T: tuple](h5f: H5File, x: T, name = "", path = "/") =
+  ## An tuple is stored as an attribute with `name` under `path`. It is stored
+  ## as a composite datatype. If each field of the tuple is not a supported
+  ## flat object, this may raise or yield a compile time error.
+  let obj = h5f[path.grp_str]
+  obj.attrs[name] = x
+
 template innerTyp(x: typed): untyped =
   ## Argument should be a `seq`, but at least iterable via `[]`
   typeof(x[0])

--- a/src/nimhdf5/type_utils.nim
+++ b/src/nimhdf5/type_utils.nim
@@ -139,10 +139,13 @@ macro offsetStr*(x: typed, f: static string): untyped =
     #echo "Offset of: ", `f`, " for ", `x`
     offsetOf(`x`, `id`)
 
+
+from util import address
+
 proc offsetOfTup*[T: tuple](x: T, idx: static int): int =
   ## Returns the offset of fields in an anonymous tuple by subtracting the
   ## base address of the tuple (field 0) from the target field at index `idx`.
-  template getAddr(x): untyped = cast[uint](addr x)
+  template getAddr(x): untyped = cast[uint](address x)
   let baseAddr = getAddr(x[0])
   let targAddr = getAddr(x[idx])
   doAssert baseAddr <= targAddr, "Base address was: " & $baseAddr & " and targ address: " & $targAddr

--- a/src/nimhdf5/type_utils.nim
+++ b/src/nimhdf5/type_utils.nim
@@ -1,0 +1,166 @@
+import macros
+
+#[
+Some utility macros that deal with converting an existing type into a type
+that contains `ptr char` fields instead of `strings` and `hvl_t` instead
+of nested (i.e. VLEN) sequences
+]#
+
+from hdf5_wrapper import hvl_t
+
+proc typeNeedsCopy(n: NimNode): bool
+proc needsCopyImpl(typ: NimNode): bool =
+  result = false
+  let implNode = if typ.kind == nnkObjectTy: typ[2] else: typ
+  for ch in implNode:
+    if ch.kind == nnkIdentDefs:
+      let nTyp = ch[1]
+      result = result or nTyp.typeNeedsCopy()
+    elif typ.kind == nnkTupleConstr: # the fields are the types of the anonymous fields
+      result = result or ch.typeNeedsCopy()
+    elif typ.kind == nnkBracketExpr:
+      # check all bracket expression children
+      result = result or ch.typeNeedsCopy()
+    else:
+      doAssert false, "Invalid branch: " & $ch.kind & " and " & $ch.typeKind
+
+proc typeNeedsCopy(n: NimNode): bool =
+  case n.kind
+  of nnkSym:
+    if n.typeKind in {ntyString, ntySequence}:
+      result = true
+    elif n.typeKind in {ntyTuple, ntyObject}:
+      result = n.getTypeImpl.needsCopyImpl()
+    else:
+      result = n.typeKind notin {ntyBool, ntyChar, ntyInt .. ntyUint64}
+  of nnkIdent:
+    result = n.strVal == "string"
+  of nnkPtrTy, nnkBracketExpr: ## XXX: study generics?
+    result = false
+  of nnkTupleConstr, nnkTupleTy:
+    result = n.needsCopyImpl()
+  else:
+    doAssert false, "Unsupported node: " & $n.treerepr
+
+macro needsCopy*(t: typed): untyped =
+  ## Checks if the given type contains any fields that requires a copy. Currently that means
+  ## it or a nested type contains a `string` field or a `seq` indicating VLEN data.
+  doAssert t.typeKind == ntyTypeDesc, "Argument was: " & $t.typeKind & " instead of `ntyTypeDesc`."
+  let typ = t.getType[1]
+  case typ.typeKind
+  of ntyString, ntySequence: result = newLit true
+  of ntyBool, ntyChar, ntyInt .. ntyUint64:
+    result = newLit false
+  of ntyObject, ntyTuple:
+    case typ.kind
+    of nnkSym:
+      result = newLit(needsCopyImpl(typ.getTypeImpl))
+    of nnkObjectTy, nnkTupleTy, nnkTupleConstr, nnkBracketExpr:
+      result = newLit(needsCopyImpl(typ))
+    else:
+      doAssert false, "Type kind was = " & $typ.kind & " of " & $t.repr & " and " & $typ.treerepr
+  else:
+    result = newLit false
+
+proc replaceField(n: NimNode, replaceVlen: bool): NimNode
+proc replaceFields(typ: NimNode, replaceVlen: bool): NimNode =
+  let implNode = if typ.kind == nnkObjectTy: typ[2] else: typ
+
+  case typ.typeKind
+  of ntySequence:
+    result = bindSym"hvl_t"
+  else:
+    result = nnkTupleTy.newTree()
+    for i, ch in implNode:
+      if ch.kind == nnkIdentDefs:
+        result.add nnkIdentDefs.newTree(ident(ch[0].strVal),
+                                        ch[1].replaceField(replaceVlen),
+                                        newEmptyNode())
+      elif typ.kind == nnkTupleConstr: # anonymous tuple with types as args
+        result.add nnkIdentDefs.newTree(ident("Field_" & $i),
+                                        ch.replaceField(replaceVlen),
+                                        newEmptyNode())
+      elif typ.kind == nnkBracketExpr:
+        # check all bracket expression children
+        result.add nnkIdentDefs.newTree(ident("Field_" & $i),
+                                        ch.replaceField(replaceVlen),
+                                        newEmptyNode())
+      else:
+        doAssert false, "Invalid branch"
+
+proc replaceField(n: NimNode, replaceVlen: bool): NimNode =
+  case n.kind
+  of nnkSym:
+    if n.typeKind == ntyString:
+      result = nnkPtrTy.newTree(ident"char")
+    elif n.typeKind == ntySequence:
+      ## XXX: check if *INNER* type is also sequence
+      ##   -> seq[hvl_t]
+      ##   else ->: hvl_t
+      result = if replaceVlen: bindSym"hvl_t"
+               else: n
+    elif n.typeKind in {ntyTuple, ntyObject}:
+      result = n.getTypeImpl.replaceFields(replaceVlen)
+    else:
+      result = n
+  of nnkIdent, nnkPtrTy, nnkBracketExpr: ## XXX: study generics (bracket expr)?
+    result = n
+  of nnkTupleTy, nnkTupleConstr:
+    result = n.replaceFields(replaceVlen)
+  else:
+    doAssert false, "Unsupported node: " & $n.treerepr
+
+macro genCompatibleTuple*(t: typed, replaceVlen: static bool): untyped =
+  ## Generates a tuple type from `t` that is equivalent except has all string fields
+  ## replaced by `cstring` fields
+  let typ = t.getType[1].getTypeImpl
+  doAssert typ.kind in {nnkObjectTy, nnkTupleTy, nnkTupleConstr, nnkBracketExpr, nnkSym}, "Instead got " & $typ.kind
+  case typ.typeKind
+  of ntyString:
+    result = nnkPtrTy.newTree(ident"char") #ident"pointer" #ident"cstring"
+  of ntySequence:
+    result = bindSym"hvl_t"
+  else:
+    result = replaceFields(typ, replaceVlen)
+
+macro printType*(t: typed): untyped =
+  result = newStmtList()
+  proc addEcho(x: string): NimNode =
+    result = nnkCall.newTree(ident"echo", newLit x)
+  result.add addEcho(t.getType.repr)
+
+macro typeName*(t: typed): untyped =
+  result = newLit t.getType.repr
+
+macro offsetStr*(x: typed, f: static string): untyped =
+  ## Access the `offsetOf` procedure given a static string from `fieldPairs`
+  let id = ident(f)
+  result = quote do:
+    #echo "Offset of: ", `f`, " for ", `x`
+    offsetOf(`x`, `id`)
+
+proc offsetOfTup*[T: tuple](x: T, idx: static int): int =
+  ## Returns the offset of fields in an anonymous tuple by subtracting the
+  ## base address of the tuple (field 0) from the target field at index `idx`.
+  template getAddr(x): untyped = cast[uint](addr x)
+  let baseAddr = getAddr(x[0])
+  let targAddr = getAddr(x[idx])
+  doAssert baseAddr <= targAddr, "Base address was: " & $baseAddr & " and targ address: " & $targAddr
+  #echo "OffsetOfTup: ", x, " at ", idx
+  result = int(targAddr - baseAddr)
+
+import std / strutils # import removePrefix
+from std / sugar import dup
+macro offsetTup*(x: typed, f: static string): untyped =
+  ## Helper to return the offset of a tuple based on the field name. Can be
+  ## an anonymous tuple.
+  if f.startsWith("Field"): # anonymous most likely
+    let idx = parseInt(f.dup(removePrefix("Field")))
+    result = quote do:
+      offsetOfTup(`x`, `idx`)
+  else:
+    # non anonymous, reuse regular macro
+    let id = ident(f)
+    result = quote do:
+      #echo "Offset of for tuple: ", `f`, " for ", `x`
+      offsetOf(`x`, `id`)

--- a/src/nimhdf5/util.nim
+++ b/src/nimhdf5/util.nim
@@ -26,7 +26,7 @@ proc formatName*(name: string): string =
   # do this by trying to strip any leading and trailing / from name (plus newline,
   # whitespace, if any) and then prepending a leading /
   # Note: we use `normalizePath` only for the behavior of `./`, `..` and multiple `/`
-  result = "/" & name.normalizePath().strip(chars = ({'/'} + Whitespace + NewLines))
+  result = "/" & name.replace(" ", "_").normalizePath().strip(chars = ({'/'} + Whitespace + NewLines))
 
 template getParent*(dset_name: string): string =
   ## given a `dset_name` after formating (!), return the parent name,

--- a/src/nimhdf5/util.nim
+++ b/src/nimhdf5/util.nim
@@ -26,7 +26,7 @@ proc formatName*(name: string): string =
   # do this by trying to strip any leading and trailing / from name (plus newline,
   # whitespace, if any) and then prepending a leading /
   # Note: we use `normalizePath` only for the behavior of `./`, `..` and multiple `/`
-  result = "/" & name.replace(" ", "_").normalizePath().strip(chars = ({'/'} + Whitespace + NewLines))
+  result = "/" & name.normalizePath().strip(chars = ({'/'} + Whitespace + NewLines))
 
 template getParent*(dset_name: string): string =
   ## given a `dset_name` after formating (!), return the parent name,

--- a/src/nimhdf5/util.nim
+++ b/src/nimhdf5/util.nim
@@ -88,3 +88,9 @@ iterator iterateEnumSet*[T](s: set[T]): T =
   for field in iterateEnumFields(T):
     if field in s:
       yield field
+
+template address*(x: typed): untyped =
+  when (NimMajor, NimMinor, NimPatch) < (1, 9, 0):
+    unsafeAddr(x)
+  else:
+    addr(x)

--- a/tests/tCompound.nim
+++ b/tests/tCompound.nim
@@ -4,12 +4,14 @@ const
   File = "tests/tCompound.h5"
   Dset = "DComp"
   DsetTup = "DCompTup"
+  DsetAnTup = "DCompAnTup"
 
 type
   Comp = object
     a: float
+    c: float32 ## having float32 here tests that Nim's alignment is correctly taken care of
+               ## (another 4 byte after the float32)
     b: int
-    c: float32
 
   Tup = tuple
     d: float
@@ -25,19 +27,32 @@ proc assert_dataset[T](h5f: H5File, data: seq[T], name: string) =
   let readData = dset[T]
   doAssert readData == data
 
+import typetraits
 when isMainModule:
   var data = newSeq[Comp](10)
   var dataTup = newSeq[Tup](10)
+  var dataAnTup = newSeq[(float, float32, int)](10) ## anonymous tuple to check we get correct alignment for these
   for i in 0 ..< 10:
-    data[i] = Comp(a: i.float * 1.1, b: i, c: i.float32 / 1.111)
+    let x = Comp(a: i.float * 1.1, b: i, c: i.float32 / 1.111'f32)
+    #echo sizeof(x)
+    data[i] = x
+    let y = (i.float * 1.1, i.float32 / 1.111'f32, i)
+    dataAnTup[i] = y
+    #echo sizeof(y)
+    #echo sizeof(y[0]), " addr ", cast[uint](addr(y[0]))
+    #echo sizeof(y[1]), " addr ", cast[uint](addr(y[1]))
+    #echo sizeof(y[2]), " addr ", cast[uint](addr(y[2]))
     dataTup[i] = (d: i.float * 2.5, e: i * 2, f: i * 3)
+
 
   var h5f = H5open(File, "rw")
 
   h5f.write_dataset(data, Dset)
   h5f.write_dataset(dataTup, DsetTup)
+  h5f.write_dataset(dataAnTup, DsetAnTup)
   h5f.assert_dataset(data, Dset)
   h5f.assert_dataset(dataTup, DsetTup)
+  h5f.assert_dataset(dataAnTup, DsetAnTup)
 
   var err = h5f.close()
   assert err >= 0
@@ -45,6 +60,7 @@ when isMainModule:
   h5f = H5open(File, "r")
   h5f.assert_dataset(data, Dset)
   h5f.assert_dataset(dataTup, DsetTup)
+  h5f.assert_dataset(dataAnTup, DsetAnTup)
 
   err = h5f.close()
   assert err >= 0

--- a/tests/tCompoundWithBool.nim
+++ b/tests/tCompoundWithBool.nim
@@ -1,0 +1,29 @@
+import nimhdf5
+
+## XXX: MAKE ME A PROPER TEST
+type
+  FadcCuts* = object
+    active: bool # only a valid cut if `active`, used to indicate we had data for this FADC setting
+    riseLow: float
+    riseHigh: float
+    fallLow: float
+    fallHigh: float
+    skewness: float
+
+const File = "/tmp/test_file_bool.h5"
+var h5f = H5open(File, "rw")
+
+let data = @[FadcCuts(active: true, riseLow: 40, riseHigh: 100, fallLow: 200, fallHigh: 400, skewness: -0.8),
+             FadcCuts(active: false, riseLow: 0, riseHigh: 0, fallLow: 100, fallHigh: 300, skewness: 0.0)]
+var dset = h5f.create_dataset("/w_bool",
+                              2,
+                              FadcCuts)
+dset[dset.all] = data
+
+discard h5f.close()
+
+
+h5f = H5open(File, "r")
+let read = h5f["/w_bool", FadcCuts]
+echo read
+discard h5f.close()

--- a/tests/tCompoundWithSeq.nim
+++ b/tests/tCompoundWithSeq.nim
@@ -1,0 +1,111 @@
+import tables, nimhdf5
+
+proc writeDeserTest[T](x: T, f: string) =
+  x.toH5(f)
+
+  let xx = deserializeH5[T](f)
+  echo "Deserialized: ", xx
+
+  ## Verify they are the same!
+  doAssert xx == x
+
+block Float:
+  let file = "/tmp/cacheTab_float.h5"
+  type
+    TabKey = (int, string)
+    TabVal = float
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = 123.54
+
+  writeDeserTest(cacheTab, file)
+
+block String:
+  let file = "/tmp/cacheTab_string.h5"
+  type
+    TabKey = (int, string)
+    TabVal = string
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = "HALO"
+
+  writeDeserTest(cacheTab, file)
+
+block SeqInt:
+  let file = "/tmp/cacheTab_seqint.h5"
+  type
+    TabKey = (int, string)
+    TabVal = seq[int]
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = @[1, 2, 3, 4, 5] #@[1.1, 1.12, 123.54]
+
+  writeDeserTest(cacheTab, file)
+
+block SeqFloat:
+  let file = "/tmp/cacheTab_seqfloat.h5"
+  type
+    TabKey = (int, string)
+    TabVal = seq[float]
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = @[1.1, 1.12, 123.54]
+
+  writeDeserTest(cacheTab, file)
+
+block SeqString:
+  let file = "/tmp/cacheTab_seqstring.h5"
+  type
+    TabKey = (int, string)
+    TabVal = seq[string]
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = @["A", "HALO"]
+
+  writeDeserTest(cacheTab, file)
+
+block SeqTuple:
+  let file = "/tmp/cacheTab_seqtuple.h5"
+  type
+    TabKey = (int, string)
+    TabVal = seq[(int, float)]
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = @[(1, 1.2), (5, 123.4)]
+
+  writeDeserTest(cacheTab, file)
+
+block SeqTupleStr:
+  let file = "/tmp/cacheTab_seqtuple_str.h5"
+  type
+    TabKey = (int, string)
+    TabVal = seq[(string, float)]
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = @[("A", 1.2), ("HALO", 123.4)]
+
+  writeDeserTest(cacheTab, file)
+
+block SeqFloatLarge:
+  let file = "/tmp/cacheTab_seqfloat_large.h5"
+  type
+    TabKey = (int, string)
+    TabVal = seq[float]
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal]()
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = @[1.2, 3.21, 543.4]
+
+  writeDeserTest(cacheTab, file)
+
+block TrickyTuples:
+  let file = "/tmp/cacheTab_tricky_tuples.h5"
+  ## This checks whether we handle alignment within a tuple that does not need to be
+  ## converted, but is contained in an outer tuple that is converted.
+  type
+    TabKey = (int, string)
+    TabVal = (int, float32, float)
+    CacheTabTyp = Table[TabKey, TabVal]
+  var cacheTab = initTable[TabKey, TabVal](1)
+  cacheTab[(232, "DEGA5e09EEGNAGEN")] = (4, 1.2'f32, 53.2)
+
+  writeDeserTest(cacheTab, file)

--- a/tests/tCompoundWithVlenStr.nim
+++ b/tests/tCompoundWithVlenStr.nim
@@ -1,0 +1,100 @@
+import nimhdf5, seqmath, os, tables
+
+import nimhdf5 / type_utils # for convertToCstring
+
+const
+  File = "tests/tCompoundWithVlenStr.h5"
+  Dset = "DComp"
+  DsetTup = "DCompTup"
+
+const CacheTabFile = "/dev/shm/cacheTab_effective_eff_test.h5"
+type
+  TabKey = (string, string, float)
+  #         ^-- calibration filename
+  #                 ^-- sha1 hash of the NN model `.pt` file
+  #                         ^-- target efficiency
+  TabVal = (float, float)
+  #         ^-- mean of effective effs
+  #                ^-- σ of effective effs
+  CacheTabTyp = Table[TabKey, TabVal]
+
+type
+  Comp = object
+    a: float
+    b: int
+    c: float32
+    s: string
+    x: Tup
+
+  Tup = tuple
+    d: float
+    e: int
+    f: int
+    t: string
+
+const Size = 10
+
+proc write_dataset[T](h5f: H5File, data: seq[T], name: string) =
+  var dset = h5f.create_dataset(name, Size, T)
+  #if name == "dt3":
+  dset[dset.all] = data
+
+proc assert_dataset[T](h5f: H5File, data: seq[T], name: string) =
+  let dset = h5f[name.dset_str]
+  let readData = dset[T]
+  doAssert readData == data
+
+when isMainModule:
+  var data = newSeq[Comp](Size)
+  var dataTup = newSeq[Tup](Size)
+  for i in 0 ..< Size:
+    let tup = (d: i.float * 2.5, e: i * 2, f: i * 3, t: "World")
+    data[i] = Comp(a: i.float * 1.1, b: i, c: i.float32 / 1.111, s: "Hello", x: tup)
+    dataTup[i] = tup
+
+  echo "SIZEOF CZM ", sizeof(Comp)
+  let sasa = data[0]
+  for f, v in fieldPairs(sasa):
+    echo "Size of ", f, " = ", sizeof(v)
+  var h5f = H5open(File, "rw")
+
+
+  let dt3 = data.convertToCstring()
+  echo "DT3!!! ", dt3
+  h5f.write_dataset(dt3, "dt3")
+  echo "NOW PART 2\n\n"
+  h5f.write_dataset(data, Dset)
+
+  h5f.write_dataset(dataTup, DsetTup)
+  h5f.assert_dataset(data, Dset)
+  h5f.assert_dataset(dataTup, DsetTup)
+
+
+
+  ### XXX: make me a test!
+  #var cacheTab = initTable[TabKey, TabVal](1)
+  #for i in 0 ..< 6:
+  #  cacheTab[("Calib.h5", "D73DENGNE483848ENRERNE", 0.1 * i.float)] = (0.91243, 0.03)
+  #echo "serializing:: "
+  #for k, v in cacheTab:
+  #  echo k, " of ", v
+  #cacheTab.toH5(CacheTabFile)
+  #
+  #cacheTab = deserializeH5[CacheTabTyp](CacheTabFile)
+  #
+  #echo "ater deserializing:: "
+  #for k, v in cacheTab:
+  #  echo k, " of ", v
+  #
+  #
+  #var err = h5f.close()
+  #assert err >= 0
+  #
+  #h5f = H5open(File, "r")
+  #h5f.assert_dataset(data, Dset)
+  #h5f.assert_dataset(dataTup, DsetTup)
+  #
+  #err = h5f.close()
+  #assert err >= 0
+
+  #removeFile(File)

--- a/tests/tCompoundWithVlenStr.nim
+++ b/tests/tCompoundWithVlenStr.nim
@@ -52,17 +52,17 @@ when isMainModule:
     data[i] = Comp(a: i.float * 1.1, b: i, c: i.float32 / 1.111, s: "Hello", x: tup)
     dataTup[i] = tup
 
-  echo "SIZEOF CZM ", sizeof(Comp)
-  let sasa = data[0]
-  for f, v in fieldPairs(sasa):
-    echo "Size of ", f, " = ", sizeof(v)
+  #echo "SIZEOF CZM ", sizeof(Comp)
+  #let sasa = data[0]
+  #for f, v in fieldPairs(sasa):
+  #  echo "Size of ", f, " = ", sizeof(v)
   var h5f = H5open(File, "rw")
 
 
-  let dt3 = data.convertToCstring()
-  echo "DT3!!! ", dt3
-  h5f.write_dataset(dt3, "dt3")
-  echo "NOW PART 2\n\n"
+  #let dt3 = data.convertToCstring() # <- this is irrelevant now
+  #echo "DT3!!! ", dt3
+  #h5f.write_dataset(dt3, "dt3")
+  #echo "NOW PART 2\n\n"
   h5f.write_dataset(data, Dset)
 
   h5f.write_dataset(dataTup, DsetTup)

--- a/tests/tSerialize.nim
+++ b/tests/tSerialize.nim
@@ -1,0 +1,88 @@
+#[
+Simple example showing how objects can be serialized (even ref objects)
+and how the functionality is extended using custom `toH5` procedures,
+here done for arraymancer `Tensor` and datamancer `DataFrame` types.
+]#
+
+from os import `/`
+import nimhdf5
+import datamancer
+
+type
+  Bar = object
+    a: int
+    c: char
+
+  TheKind = enum
+    tkA, tkB
+
+  TestFloat = distinct float
+
+  Foo = ref object
+    x: float
+    y: int
+    z: seq[int]
+    s: string
+    b: Bar
+    tf: TestFloat
+    files: seq[string]
+    case kind: TheKind
+    of tkA: lol: int
+    of tkB: lmao: float
+    test: int
+    df: DataFrame
+
+## Test extending the
+proc toH5[T](h5f: H5File, x: Tensor[T], name = "", path = "/") =
+  ## Stores the given arraymancer `Tensor` in the given H5 file using the
+  ## shape info to construct an equivalent dataset.
+  echo "Constructing: ", path / name
+  let dset = h5f.create_dataset(path / name,
+                                @(x.shape), # 1D, so use length
+                                T)
+  when T is KnownSupportsCopyMem:
+    dset.unsafeWrite(x.toUnsafeView(), x.size.int)
+  else:
+    dset[dset.all] = x.toSeq1D
+
+
+proc toH5(h5f: H5File, x: DataFrame, name = "", path = "/") =
+  ## Stores the given datamancer `DataFrame` as in the H5 file.
+  ## This is done by constructing a group for the dataframe and then adding
+  ## each column as a 1D dataset.
+  ##
+  ## Alternatively we could also store it as a composite datatype, but that is less
+  ## efficient for reading individual columns.
+  let grp = path / name
+  discard h5f.create_group(grp)
+  for k in getKeys(x):
+    withNativeTensor(x[k], val):
+      echo val
+      when typeof(val) isnot Tensor[Value]:
+        h5f.toH5(val, k, grp)
+      else:
+        echo "[WARNING]: writing object column " & $k & " as string values!"
+        h5f.toH5(val.valueTo(string), k, grp)
+
+proc toH5[T](x: T,
+             file: string,
+             path: string = "/") = # group in the file (to add to an existing file for example
+  var h5f = H5File(file, "rw")
+  h5f.toH5(x, path)
+  let err = h5f.close()
+  if err != 0:
+    raise newException(IOError, "Failed to close the H5 file " & $file & " after writing.")
+
+let b = Bar(a: 123, c: 'x')
+let df = toDf({"x" : @[1, 2, 3], "y" : @["a", "b", "c"]})
+
+let x = Foo(x: 5.5, y: 10, z: @[1, 2, 3, 4, 5], s: "hello", files: @["/tmp/test.txt", "/tmp/foo.txt"], b: b,
+            tf: 5.5.TestFloat,
+            kind: tkA, lol: 5, test: 6,
+            df: df)
+
+x.toH5("/tmp/test.h5", path = "/SubPath")
+
+## XXX: Ideally we'd turn this into a proper test case that checks
+## the content actually shows up as it should. We do that by hand
+## right now as I don't want to waste more time on this at the moment.

--- a/tests/tSerialize.nim
+++ b/tests/tSerialize.nim
@@ -45,7 +45,6 @@ proc toH5[T](h5f: H5File, x: Tensor[T], name = "", path = "/") =
   else:
     dset[dset.all] = x.toSeq1D
 
-
 proc toH5(h5f: H5File, x: DataFrame, name = "", path = "/") =
   ## Stores the given datamancer `DataFrame` as in the H5 file.
   ## This is done by constructing a group for the dataframe and then adding
@@ -63,15 +62,6 @@ proc toH5(h5f: H5File, x: DataFrame, name = "", path = "/") =
       else:
         echo "[WARNING]: writing object column " & $k & " as string values!"
         h5f.toH5(val.valueTo(string), k, grp)
-
-proc toH5[T](x: T,
-             file: string,
-             path: string = "/") = # group in the file (to add to an existing file for example
-  var h5f = H5File(file, "rw")
-  h5f.toH5(x, path)
-  let err = h5f.close()
-  if err != 0:
-    raise newException(IOError, "Failed to close the H5 file " & $file & " after writing.")
 
 let b = Bar(a: 123, c: 'x')
 let df = toDf({"x" : @[1, 2, 3], "y" : @["a", "b", "c"]})

--- a/tests/tattributes.nim
+++ b/tests/tattributes.nim
@@ -20,28 +20,28 @@ proc write_attrs(grp: var H5Group) =
 
 proc assert_attrs(grp: var H5Group) =
 
-  assert(grp.attrs["Time", string] == TimeStr)
-  assert(grp.attrs["Counter", int] == Counter)
-  assert(grp.attrs["Seq", seq[int]] == SeqAttr)
-  assert("Time" in grp.attrs)
-  assert("NoTime" notin grp.attrs)
+  doAssert(grp.attrs["Time", string] == TimeStr)
+  doAssert(grp.attrs["Counter", int] == Counter)
+  doAssert(grp.attrs["Seq", seq[int]] == SeqAttr)
+  doAssert("Time" in grp.attrs)
+  doAssert("NoTime" notin grp.attrs)
   let nameCheck = if grp.attrs.parent_name == formatName(GrpName) or
                      grp.attrs.parent_name == formatName(GrpCopy):
                     true
                   else:
                     false
-  assert(nameCheck)
-  assert(grp.attrs.parent_type == "H5Group")
-  assert(grp.attrs.num_attrs == 3)
+  doAssert(nameCheck)
+  doAssert(grp.attrs.parent_type == "H5Group")
+  doAssert(grp.attrs.num_attrs == 3)
 
 proc assert_delete(grp: var H5Group) =
 
-  assert(grp.deleteAttribute("Time"))
-  assert(grp.attrs.num_attrs == 2)
-  assert(grp.deleteAttribute("Counter"))
-  assert(grp.attrs.num_attrs == 1)
-  assert(grp.deleteAttribute("Seq"))
-  assert(grp.attrs.num_attrs == 0)
+  doAssert(grp.deleteAttribute("Time"))
+  doAssert(grp.attrs.num_attrs == 2)
+  doAssert(grp.deleteAttribute("Counter"))
+  doAssert(grp.attrs.num_attrs == 1)
+  doAssert(grp.deleteAttribute("Seq"))
+  doAssert(grp.attrs.num_attrs == 0)
 
 proc assert_overwrite(grp: var H5Group) =
   var mcounter = Counter
@@ -68,8 +68,7 @@ proc assert_overwrite(grp: var H5Group) =
   grp.attrs["Counter"] = mcounter
   doAssert(grp.attrs["Counter", int] == mcounter)
 
-when isMainModule:
-
+proc main() =
   var
     h5f = H5open(File, "rw")
     grp = h5f.create_group(GrpName)
@@ -86,7 +85,7 @@ when isMainModule:
   grpCp.assert_attrs
 
   err = h5f.close()
-  assert(err >= 0)
+  doAssert(err >= 0)
 
   # open again, again with write access to delete attributes again
   h5f = H5open(File, "rw")
@@ -103,7 +102,10 @@ when isMainModule:
   grp.assert_overwrite
 
   err = h5f.close()
-  assert(err >= 0)
+  doAssert(err >= 0)
 
   # clean up after ourselves
   removeFile(File)
+
+when isMainModule:
+  main()

--- a/tests/twrite_string.nim
+++ b/tests/twrite_string.nim
@@ -45,16 +45,20 @@ proc readVlenString(h5f: H5File) =
   let data = h5f["vlen_strings", string]
   doAssert data == Data
 
-proc writeAsVlen(h5f: H5File) =
-  ## NOTE: writing a string as such will make it appear as pure `uint8` VLEN data in the file. Not
-  ## recommended!
-  let dset = h5f.create_dataset("strings_as_vlen", 3, special_type(char))
-  dset[dset.all] = Data
 
-  when compiles((discard h5f.create_dataset("strings_as_vlen_string", 3, special_type(string)))):
-    doAssert false, "Call to `special_type(string)` does not fail! This is a regression."
-  else:
-    discard
+## NOTE: This "feature" is not supported anymore. I will keep this test around to think about
+## it again in the future (i.e. whether this should work after all in the way that this test
+## shows or if it's fine to not support at all. A `string` is *not* a `seq[char]` after all!)
+#proc writeAsVlen(h5f: H5File) =
+#  ## NOTE: writing a string as such will make it appear as pure `uint8` VLEN data in the file. Not
+#  ## recommended!
+#  let dset = h5f.create_dataset("strings_as_vlen", 3, special_type(char))
+#  dset[dset.all] = Data
+#
+#  when compiles((discard h5f.create_dataset("strings_as_vlen_string", 3, special_type(string)))):
+#    doAssert false, "Call to `special_type(string)` does not fail! This is a regression."
+#  else:
+#    discard
 
 proc readAsVlen(h5f: H5File) =
   let data = h5f["strings_as_vlen", special_type(char), char]
@@ -66,7 +70,7 @@ when isMainModule:
 
   writeFixed(h5f)
   writeVlenString(h5f)
-  writeAsVlen(h5f)
+  #writeAsVlen(h5f)
 
   doAssert h5f.close() >= 0
 
@@ -74,7 +78,7 @@ when isMainModule:
 
   h5f.readFixed()
   h5f.readVlenString()
-  h5f.readAsVlen()
+  #h5f.readAsVlen()
 
   doAssert h5f.close() >= 0
 


### PR DESCRIPTION
Add basic serialization submodule to auto serialize most objects to
a H5 file. Scalar types are written as attributes and non scalar as
datasets.
Can be extended for complicated custom types by using the ~toH5~
hook. See the ~tSerialize.nim~ test and the ~serialize.nim~ file.
Note: currently no deserialization is supported. You need to parse
the data back into your file if needed. An equivalent inverse can be
added, but has no priority at the moment.


*UPDATE*: This has gotten significantly more massive. Supporting serialization meant supporting more complicated types of objects as compound types. Then also requiring deserialization and finally fixing a serious memory leak in the `hid_t` identifiers. 


The full changelog now:
```
* v0.5.3
  - add basic serialization submodule to auto serialize most objects to
    a H5 file. Scalar types are written as attributes and non scalar as
    datasets.
    Can be extended for complicated custom types by using the ~toH5~
    hook. See the ~tSerialize.nim~ test and the ~serialize.nim~ file.
    Note: currently no deserialization is supported. You need to parse
    the data back into your file if needed. An equivalent inverse can be
    added, but has no priority at the moment.
  - allow usage of tilde =~= in paths to H5 files
  - replace distinct `hid_t` types by traced 'fat' objects

    The basic idea here is the following:
    The `hid_t` identifiers all refer to objects that live in the H5
    library (and possibly in a file). In our previous approach we kept
    track of different types by using `distinct hid_t` types. That's great
    because we cannot mix and match the wrong type of identifiers in a
    given context.
    However, there are real resources underlying each identifier. Most
    identifiers require the user to call a `close` / `free` type of
    routine. While we can associate a destructor with a `=destroy` hook to
    a `distinct hid_t` (with `hid_t` just being an integer type), the
    issue is *when* that destructor is being called. In this old way the
    identifier is a pure value type. If an identifier is copied and the
    copy goes out of scope early, we release the resource despite still
    needing it!
    Therefore, we now have a 'fat' object that knows its internal
    id (just a real `hid_t`) and which closing function to call. Our
    actual IDs then are `ref objects` of these fat objects.
    That way we get sane releasing of resources in the correct moments,
    i.e. when the last reference to an identifier goes out of scope. This
    is the correct thing to do in 99% of the cases.
  - add ~FileID~ field to parent file for datasets, similar to already
    present for groups. Convenient in practice.
  - refactor ~read~ and ~write~ related procs. The meat of the code is
    now handled in one procedure each (which also takes care of
    reclaiming VLEN memory for example).
  - greatly improve automatic writing and reading of complex datatypes
    including Nim objects that contain ~string~ fields or other VLEN
    data. This is performed by performing a *copy* to a suitable
    datatype that matches the H5 definition of the equivalent data in
    Nim.
    ~type_utils~ and ~copyflat~ submodules are added to that end.
    In this context there is some trickyness involved, which causes the
    implementation to be more complex than one might expect. The
    necessity to get the correct alignment between naive `offsetOf`
    expectations and the reality of how structs are packed.

```