### PR TITLE
Buffer improvements for `copyflat`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-6, devel]
+        branch: [version-2-0, version-1-6, devel]
         target: [linux] #, macos, windows]
         include:
           - target: linux

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.5.4
+- fixes potential source of segfaults in ~copyflat~ where we could
+  call ~allocShared0~ with a ~0~ argument
+- support ~array~ types to be written (at least as part of a compound
+  datatype)
+- improve warning message when importing ~blosc~ filters without the
+  Nim ~blosc~ library installed    
 * v0.5.3
 - *Drops support for Nim 1.4*
 - add basic serialization submodule to auto serialize most objects to

--- a/src/nimhdf5/blosc_filter.nim
+++ b/src/nimhdf5/blosc_filter.nim
@@ -16,7 +16,7 @@ when defined(blosc):
   else:
     const HasBloscSupport* = false
     static:
-      warning("Compiling without blosc support")
+      warning("Compiling without blosc support, because the `blosc` library cannot be found.")
 else:
   const HasBloscSupport* = false
   static:

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -14,10 +14,8 @@ type
 proc `=copy`(dest: var BufferObj, source: BufferObj) {.error: "Copying a buffer is not allowed at the moment.".}
 
 proc `=destroy`(x: var BufferObj) =
-  for ch in mitems(x.children):
-    `=destroy`(ch)
+  `=destroy`(x.children)
   if x.owned and x.data != nil:
-    #echo "deallocing: ", x.offsetOf
     deallocShared(x.data)
 
 proc `$`*(b: Buffer): string =

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -17,6 +17,7 @@ proc `=destroy`(x: var BufferObj) =
   `=destroy`(x.children)
   if x.owned and x.data != nil:
     deallocShared(x.data)
+    x.data = nil
 
 proc `$`*(b: Buffer): string =
   result = "Buffer(size: " & $b.size & ", owned: " & $b.owned & ", data: " & $b.data.repr & ", offsetOf: " & $b.offsetOf & ", children: " & $b.children.len & ")"

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -81,6 +81,11 @@ proc copyFlat[T: distinct](buf: var Buffer, x: T) =
   var target = buf.data +% buf.offsetOf
   target.copyMem(address(x), size)
 
+proc copyFlat[T; N: static int](buf: var Buffer, x: array[N, T]) =
+  let size = calcSize(x)
+  var target = buf.data +% buf.offsetOf
+  target.copyMem(address(x[0]), size)
+
 proc getAddr(x: string): uint =
   if x.len > 0:
     result = cast[uint](address(x[0]))
@@ -96,7 +101,7 @@ proc copyFlat[T](buf: var Buffer, x: seq[T]) =
   let child = copyFlat(x)
   buf.children.add child
   # copy child address
-  buf.copyFlat((csize_t(x.len), cast[uint](child.data)))
+  buf.copyFlat((csize_t(x.len), cast[uint](child.data))) # `hvl_t` like data structure
 
 import ./type_utils
 proc copyFlat[T: object | tuple](buf: var Buffer, x: T) =

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -11,6 +11,8 @@ type
 
   SimpleTypes* = SomeNumber | char | bool
 
+proc `=copy`(dest: var BufferObj, source: BufferObj) {.error: "Copying a buffer is not allowed at the moment.".}
+
 proc `=destroy`(x: var BufferObj) =
   for ch in mitems(x.children):
     `=destroy`(ch)

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -22,7 +22,10 @@ proc `$`*(b: Buffer): string =
   result = "Buffer(size: " & $b.size & ", owned: " & $b.owned & ", data: " & $b.data.repr & ", offsetOf: " & $b.offsetOf & ", children: " & $b.children.len & ")"
 
 proc newBuffer*(size: int, owned = true): Buffer =
-  result = Buffer(owned: owned, size: size, data: allocShared0(size), offsetOf: 0)
+  if size > 0:
+    result = Buffer(owned: owned, size: size, data: allocShared0(size), offsetOf: 0)
+  else:
+    result = Buffer(owned: false, size: size, data: nil, offsetOf: 0)
 
 proc newBuffer*(buf: pointer, size: int): Buffer =
   result = Buffer(owned: false, size: size, data: buf, offsetOf: 0)

--- a/src/nimhdf5/type_utils.nim
+++ b/src/nimhdf5/type_utils.nim
@@ -51,7 +51,7 @@ macro needsCopy*(t: typed): untyped =
   of ntyString, ntySequence: result = newLit true
   of ntyBool, ntyChar, ntyInt .. ntyUint64:
     result = newLit false
-  of ntyObject, ntyTuple:
+  of ntyObject, ntyTuple, ntyGenericInst:
     case typ.kind
     of nnkSym:
       result = newLit(needsCopyImpl(typ.getTypeImpl))

--- a/src/nimhdf5/util.nim
+++ b/src/nimhdf5/util.nim
@@ -44,6 +44,7 @@ proc traverseTree(input: NimNode): NimNode =
     case input.typeKind
     of ntyAlias, ntyTypeDesc, ntySequence: result = traverseTree(input.getTypeImpl)
     of ntyBool, ntyChar, ntyInt .. ntyUint64, ntyTuple, ntySet, ntyObject, ntyString: result = input
+    of ntyGenericInst: result = input
     else:
       doAssert false, "Invalid type kind: " & $input.typeKind
   of nnkBracketExpr:


### PR DESCRIPTION
This is the likely source of the CI failure in #62. So fixing this first.

Or not. Guess it is a regression / change / on Nim devel. Probably related to the previous bugfix about `sizeof`. Fixed.

```
* v0.5.4
- fixes potential source of segfaults in ~copyflat~ where we could
  call ~allocShared0~ with a ~0~ argument
- support ~array~ types to be written (at least as part of a compound
  datatype)
- improve warning message when importing ~blosc~ filters without the
  Nim ~blosc~ library installed    
```