### PR TITLE
fix very hard to detect segfault on Windows

### DIFF
--- a/src/nimhdf5/H5nimtypes.nim
+++ b/src/nimhdf5/H5nimtypes.nim
@@ -8,7 +8,13 @@ type
   herr_t* = cint
   # define hid_t as distinct in64 in order to not clash with normal `int64`
   hid_t* = distinct clonglong
-  time_t* = clong
+  ## NOTE: We define `time_t` by hand from `time.h` because using a definition based on
+  ## `clong` is flawed. `clong` is 8 bytes on Linux but only 4 bytes on Winodws. That leads
+  ## to mismatches in the `sizeof` of objects that contain `time_t` causing hard to understand
+  ## stack corruption bugs! Therefore we just pretend it's an object despite it actually being
+  ## an integer type. That is to make sure Nim doesn't mess up the size. `time_t` is 8 bytes
+  ## on Windows *and* Linux.
+  time_t* {.header: "<time.h>", importc: "time_t".} = object
   hbool_t* = bool
   htri_t* = cint
   hsize_t* = culonglong

--- a/src/nimhdf5/H5nimtypes.nim
+++ b/src/nimhdf5/H5nimtypes.nim
@@ -11,10 +11,11 @@ type
   ## NOTE: We define `time_t` by hand from `time.h` because using a definition based on
   ## `clong` is flawed. `clong` is 8 bytes on Linux but only 4 bytes on Winodws. That leads
   ## to mismatches in the `sizeof` of objects that contain `time_t` causing hard to understand
-  ## stack corruption bugs! Therefore we just pretend it's an object despite it actually being
-  ## an integer type. That is to make sure Nim doesn't mess up the size. `time_t` is 8 bytes
+  ## stack corruption bugs! We make it a `clonglong` by hand . `time_t` is 8 bytes
   ## on Windows *and* Linux.
-  time_t* {.header: "<time.h>", importc: "time_t".} = object
+  ## NOTE 2: I'm not entirely sure what happens on a 32-bit machine with `time_t`. I guess
+  ## it might become 4 byte sized?
+  time_t* {.header: "<time.h>", importc: "time_t".} = distinct clonglong
   hbool_t* = bool
   htri_t* = cint
   hsize_t* = culonglong


### PR DESCRIPTION
Wow, this was hard to understand!

The final explanation is:
In `getNumAttrs` we declare a variable `h5info` on the stack of type `H5O_info_t`.
Due to `time_t` being interpreted as 4 bytes, the full `H5O_info_t` type had a size of 144 bytes *for our Nim object*. But the HDF5 library expects the object to be 160 bytes. We hand a pointer to the stack object to the Nim library, which writes to it. As a result of our object being too small, the HDF5 library caused a stack corruption leading to very bizarre bugs.

My favorite:

```nim
let isItNil = h5attrs.isNil
doAssert not h5attrs.isNil, "But was it nil?" & $isItNil
```

which failed in the assertion, but printed `isItNil = false`...

The confusing part was that the API changed between 1.10 (is what I run locally on linux) and 1.12 (I run 1.14 on Windows), causing me to think the problem is in the difference between the `H5O_info_t` types. But that's not the actual problem, because the type we actually map to is `H5O_info1_t`, which is backwards compatible, because we call the `H5Oget_info2` (and friends) procedure, which takes that type as an argument. The new `H5O_info2_t` type is used in the `H5Oget_info3` function.