### PR TITLE
pretty_print: fix a few formatting issues

### DIFF
--- a/src/nimhdf5/pretty_printing.nim
+++ b/src/nimhdf5/pretty_printing.nim
@@ -128,7 +128,7 @@ proc pretty*(h5f: H5File, indent = 0, full = false): string =
   if h5f.datasets.len > 0:
     result.add &",\n{fieldInd}datasets: " & "{\n"
     for name, dset in h5f.datasets:
-      result.add &"{fieldIndTwo}{name}:\n" & dset.pretty(indent = indent + 4) & ",\n" ## [FIXME] Remove the ,
+      result.add &"{fieldIndTwo}{name}:\n" & dset.pretty(indent = indent + 4) & ",\n"
     result.add &"{fieldInd}" & "}"
   else:
     result.add &",\n{fieldInd}datasets: " & "{:}"

--- a/src/nimhdf5/pretty_printing.nim
+++ b/src/nimhdf5/pretty_printing.nim
@@ -91,10 +91,10 @@ proc pretty*(grp: H5Group, indent = 2, full = false): string =
   else:
     result.add &",\n{fieldInd}datasets: " & "{:}"
   if grp.groups.len > 0:
-    result.add &",\n{fieldInd}groups: " & "{"
+    result.add &",\n{fieldInd}groups: " & "{\n"
     for name, subGrp in grp.groups:
-      result.add &"\n{fieldIndTwo}{name},"
-    result.add fieldInd & "\n}"
+      result.add &"{fieldIndTwo}{name},\n"
+    result.add &"{fieldInd}" & "}"
   else:
     result.add &",\n{fieldInd}groups: " & "{:}"
   result.add &"\n" & repeat(' ', indent) & "}"

--- a/src/nimhdf5/pretty_printing.nim
+++ b/src/nimhdf5/pretty_printing.nim
@@ -89,14 +89,14 @@ proc pretty*(grp: H5Group, indent = 2, full = false): string =
       result.add &"{fieldInd}{name}:\n" & dset.pretty(indent = indent + 4) & ",\n"
     result.add &"{fieldInd}" & "}"
   else:
-    result.add &",\n{fieldInd}datasets: " & "{:}"
+    result.add &",\n{fieldInd}datasets: " & "{}"
   if grp.groups.len > 0:
     result.add &",\n{fieldInd}groups: " & "{\n"
     for name, subGrp in grp.groups:
       result.add &"{fieldIndTwo}{name},\n"
     result.add &"{fieldInd}" & "}"
   else:
-    result.add &",\n{fieldInd}groups: " & "{:}"
+    result.add &",\n{fieldInd}groups: " & "{}"
   result.add &"\n" & repeat(' ', indent) & "}"
 
 proc `$`*(grp: H5Group): string =
@@ -131,14 +131,14 @@ proc pretty*(h5f: H5File, indent = 0, full = false): string =
       result.add &"{fieldIndTwo}{name}:\n" & dset.pretty(indent = indent + 4) & ",\n"
     result.add &"{fieldInd}" & "}"
   else:
-    result.add &",\n{fieldInd}datasets: " & "{:}"
+    result.add &",\n{fieldInd}datasets: " & "{}"
   if h5f.groups.len > 0:
     result.add &",\n{fieldInd}groups: " & "{"
     for name, subGrp in h5f.groups:
       result.add &"\n{fieldIndTwo}{name}:\n" & subGrp.pretty(indent = indent + 4) & ","
     result.add &"\n{fieldInd}" & "}"
   else:
-    result.add &",\n{fieldInd}groups: " & "{:}"
+    result.add &",\n{fieldInd}groups: " & "{}"
   result.add &",\n{fieldInd}attrs:\n{h5f.attrs}"
   result.add &"\n" & repeat(' ', indent) & "}"
 


### PR DESCRIPTION
In addition to fixing a few misplaced new lines and commas, this change also hides some files when they are empty and removes the initial "top level" 2 character indentation.