### PR TITLE
Minor matlab fixes

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.5.9
+- fix naming of matlab field structs, due to misunderstanding on my
+  part (I thought the ~_ref~ was part of the HDF5 designation in my
+  test file)
+- allow ~references~ to yield the input dataset if it is not a
+  reference dataset  
 * v0.5.8
 - BREAKING: fix issue with dataset and group iterators, where we
   treated the root group special. The root group was off by 1 ~/~ in

--- a/examples/read_matlab.nim
+++ b/examples/read_matlab.nim
@@ -8,7 +8,6 @@ echo mat.readJson("foo").pretty()
 ## Iterate over all the sturct fields
 for k in keys(mat):
   echo k
-  echo readJson(mat, k)
   # Either use:
   echo mat.readJson(k) # to turn the data into JSON (works for ref & non ref datasets)
   # or manually iterate over all reference datasets pointed to by this key `k` (if any)

--- a/examples/read_matlab.nim
+++ b/examples/read_matlab.nim
@@ -8,6 +8,10 @@ echo mat.readJson("foo").pretty()
 ## Iterate over all the sturct fields
 for k in keys(mat):
   echo k
+  echo readJson(mat, k)
+  # Either use:
+  echo mat.readJson(k) # to turn the data into JSON (works for ref & non ref datasets)
+  # or manually iterate over all reference datasets pointed to by this key `k` (if any)
   for r in references(mat.h5f, mat[k]):
     ## `r` is now a `H5Reference`, which is a variant that may either be a H5Group
     ## or a `H5Dataset`, depending.

--- a/src/nimhdf5/h5_iterators.nim
+++ b/src/nimhdf5/h5_iterators.nim
@@ -156,19 +156,29 @@ iterator items*(group: H5Group, start_path = ".", depth = 1): H5DataSet =
         yield group.file_ref.get(dset.dset_str)
 
 from hdf5_wrapper import H5Rdereference2, H5P_DEFAULT, H5R_OBJECT, H5I_GROUP, H5I_DATASET
-iterator references*(h5f: H5File, d: H5Dataset): H5Reference =
+iterator references*(h5f: H5File, d: H5Dataset, yieldNonRefs = false): H5Reference =
   ## Iterator which yields each element that is referenced by the given dataset as
   ## a `H5Reference`. Can be either a group or a dataset.
   ##
+  ## If `yieldNonRefs` is `true` we also yield the given dataset as a `H5Reference`
+  ## if it does not actually contain a reference!
+  ##
   ## ``Still experimental!``
   # Read the references as uint64. Each element points to some other element in the HDF5 file
-  let data = d[uint64]
-  for id in data:
-    ## XXX: this is currently hardcoded to `dereference2`! Should depend on `H5_LEGACY, H5_FUTURE`
-    let obj = H5Rdereference2(d.datasetId.id, H5PDefault, H5R_Object, address id) # this is actually a `ptr haddr_t`
-    let typ = getType(obj) # get type of H5 object
-    let name = getName(obj)
-    case typ
-    of H5I_GROUP:   yield H5Reference(kind: rkGroup,   g: h5f[name.grp_str])
-    of H5I_DATASET: yield H5Reference(kind: rkDataset, d: h5f[name.dset_str])
-    else: doAssert false, "Not possible!"
+  case d.dtypeAnyKind
+  of dkRef:
+    let data = d[uint64]
+    for id in data:
+      ## XXX: this is currently hardcoded to `dereference2`! Should depend on `H5_LEGACY, H5_FUTURE`
+      let obj = H5Rdereference2(d.datasetId.id, H5PDefault, H5R_Object, address id) # this is actually a `ptr haddr_t`
+      let typ = getType(obj) # get type of H5 object
+      let name = getName(obj)
+      case typ
+      of H5I_GROUP:   yield H5Reference(kind: rkGroup,   g: h5f[name.grp_str])
+      of H5I_DATASET: yield H5Reference(kind: rkDataset, d: h5f[name.dset_str])
+      else: doAssert false, "Not possible!"
+  else:
+    if yieldNonRefs:
+      yield H5Reference(kind: rkDataset, d: d)
+    else:
+      discard

--- a/src/nimhdf5/hdf5_matlab.nim
+++ b/src/nimhdf5/hdf5_matlab.nim
@@ -8,10 +8,8 @@ type
 
 proc getFieldName(s: string): string =
   doAssert s.startsWith("/")
-  doAssert s.endsWith("_ref")
   result = s
   result.removePrefix("/")
-  result.removeSuffix("_ref")
 
 proc deserializeMatlab*(f: string): MatlabInterface =
   result = MatlabInterface(h5f: H5open(f, "r"),


### PR DESCRIPTION
```
* v0.5.9
- fix naming of matlab field structs, due to misunderstanding on my
  part (I thought the ~_ref~ was part of the HDF5 designation in my
  test file)
- allow ~references~ to yield the input dataset if it is not a
  reference dataset
```