### PR TITLE
Fix `copy` regression and usage for certain applications

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.5.11
+- fix ~copy~ implementation for certain use cases and fix a regression
+  in it
 * v0.5.10
 - fix JSON dataset reading not taking into account the shape of a
   dataset when the dataset is only simple data (same datatype)

--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -23,6 +23,7 @@ template tests(): untyped {.dirty.} =
   exec "nim c -r tests/tdset.nim"
   exec "nim c -r tests/tread_write1D.nim"
   exec "nim c -r tests/tgroups.nim"
+  exec "nim c -r tests/tcopy.nim"
   exec "nim c -r tests/tattributes.nim"
   exec "nim c -r tests/tvlen_array.nim"
   exec "nim c -r tests/tempty_hyperslab.nim"


### PR DESCRIPTION
Fixes a minor regression for `copy` and fixes it for certain applications where it was broken previously. Also adds the test case into the regular nimble `test` task.