### PR TITLE
Refactor attributes logic

### DIFF
--- a/nimhdf5.nimble
+++ b/nimhdf5.nimble
@@ -18,40 +18,47 @@ requires "https://github.com/vindaar/seqmath >= 0.1.17"
 task testDeps, "Install dependencies for tests":
   exec "nimble install -y datamancer"
 
+proc callTest(fname: string) =
+  if (NimMajor, NimMinor, NimPatch) >= (2, 0, 0):
+    exec "nim c -r " & fname
+  else: # for older Nim force usage of Orc!
+    exec "nim c -r --mm:orc " & fname
+
 template tests(): untyped {.dirty.} =
-  exec "nim c -r tests/tbasic.nim"
-  exec "nim c -r tests/tdset.nim"
-  exec "nim c -r tests/tread_write1D.nim"
-  exec "nim c -r tests/tgroups.nim"
-  exec "nim c -r tests/tcopy.nim"
-  exec "nim c -r tests/tattributes.nim"
-  exec "nim c -r tests/tvlen_array.nim"
-  exec "nim c -r tests/tempty_hyperslab.nim"
-  exec "nim c -r tests/tresize.nim"
-  exec "nim c -r tests/treshape.nim"
-  exec "nim c -r tests/tutil.nim"
-  exec "nim c -r tests/tnested.nim"
-  exec "nim c -r tests/tfilter.nim"
-  exec "nim c -r tests/toverwrite.nim"
-  exec "nim c -r tests/tconvert.nim"
-  exec "nim c -r tests/tdelete.nim"
-  exec "nim c -r tests/tresize_by_add.nim"
-  exec "nim c -r tests/tStringAttributes.nim"
-  exec "nim c -r tests/tCompound.nim"
-  exec "nim c -r tests/tCompoundWithBool.nim"
-  exec "nim c -r tests/tCompoundWithVlenStr.nim"
-  exec "nim c -r tests/tCompoundWithSeq.nim"
-  exec "nim c -r tests/tContainsIterator.nim"
-  exec "nim c -r tests/twrite_string.nim"
+  callTest "tests/tbasic.nim"
+  callTest "tests/tdset.nim"
+  callTest "tests/tread_write1D.nim"
+  callTest "tests/tgroups.nim"
+  callTest "tests/tcopy.nim"
+  callTest "tests/tattributes.nim"
+  callTest "tests/tvlen_array.nim"
+  callTest "tests/tempty_hyperslab.nim"
+  callTest "tests/tresize.nim"
+  callTest "tests/treshape.nim"
+  callTest "tests/tutil.nim"
+  callTest "tests/tnested.nim"
+  callTest "tests/tfilter.nim"
+  callTest "tests/toverwrite.nim"
+  callTest "tests/tconvert.nim"
+  callTest "tests/tdelete.nim"
+  callTest "tests/tresize_by_add.nim"
+  callTest "tests/tStringAttributes.nim"
+  callTest "tests/tCompound.nim"
+  callTest "tests/tCompoundWithBool.nim"
+  callTest "tests/tCompoundWithVlenStr.nim"
+  callTest "tests/tCompoundWithSeq.nim"
+  callTest "tests/tContainsIterator.nim"
+  callTest "tests/twrite_string.nim"
   # regression tests
-  exec "nim c -r tests/tint64_dset.nim"
-  exec "nim c -r tests/t17.nim"
-  exec "nim c -r tests/tIntegerTypes.nim"
-  exec "nim c -r tests/tWithDset.nim"
+  callTest "tests/tint64_dset.nim"
+  callTest "tests/t17.nim"
+  callTest "tests/tIntegerTypes.nim"
+  if NimMajor >= 2:
+    callTest "tests/tWithDset.nim"
   # at least run the high level examples to avoid regressions
   if fileExists("dset.h5"): # as a test, we need to get rid of the high level H5 output file
     rmFile("dset.h5")
-  exec "nim c -r examples/h5_high_level_example.nim"
+  callTest "examples/h5_high_level_example.nim"
 
 task test, "Runs all tests":
   tests()

--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -161,13 +161,13 @@ proc deleteAttribute*[T: (H5File | H5Group | H5DataSet)](h5o: T, name: string): 
   # if successful also lower the number of attributes
   h5o.attrs.num_attrs = h5o.attrs.getNumAttrs
 
-proc createAttribute(pid: ParentID, name: string, dtype: DatatypeID,
+proc createAttribute*(pid: ParentID, name: string, dtype: DatatypeID,
                      dspace: DataspaceID): AttributeID =
   ## Creates an attribute `name` under `pid` with default properties.
   result = H5Acreate2(pid.to_hid_t, name.cstring, dtype.id,
                       dspace.id, H5P_DEFAULT, H5P_DEFAULT).toAttributeID
 
-proc writeAttribute(attr_id: AttributeID, dtype: DatatypeID, data: pointer) =
+proc writeAttribute*(attr_id: AttributeID, dtype: DatatypeID, data: pointer) =
   ## Writes the given daat to the attribute.
   ##
   ## Note: This proc is inherently unsafe. The callee needs to make sure the

--- a/src/nimhdf5/datasets.nim
+++ b/src/nimhdf5/datasets.nim
@@ -41,10 +41,6 @@ proc high*(dset: H5DataSet, axis = 0): int =
   ##   int = highest index along `axis`
   result = dset.shape[axis] - 1
 
-proc isVlen*(dset: H5Dataset): bool =
-  ## Returns true if the dataset is a variable length dataset
-  result = dset.dtype_class == H5T_VLEN
-
 proc readH5*[T: ptr | pointer](dset: H5DataSet, buf: T,
                 memspaceId = H5S_ALL,
                 hyperslabId = H5S_ALL) =

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -544,6 +544,15 @@ proc getTypeClass*(dtype_id: DatatypeID): H5T_class_t =
 proc copyType*(typ: hid_t): DatatypeID =
   result = H5Tcopy(typ).toDatatypeID
 
+proc copyType*(typ: DatatypeID): DatatypeID =
+  result = H5Tcopy(typ.id).toDatatypeID
+
+proc copyDataspace*(typ: hid_t): DataspaceID =
+  result = H5Scopy(typ).toDataspaceID
+
+proc copyDataspace*(typ: DataspaceID): DataspaceID =
+  result = H5Scopy(typ.id).toDataspaceID
+
 proc close*(attr: var H5AttrObj) =
   ## closes the attribute and the corresponding dataspace
   if attr.isObjectOpen():

--- a/src/nimhdf5/h5util.nim
+++ b/src/nimhdf5/h5util.nim
@@ -525,3 +525,10 @@ proc copy*[T](h5in: H5File, h5o: T,
                     H5P_DEFAULT, H5P_DEFAULT)
 
   result = err >= 0
+
+proc isVlen*[T: H5Dataset | H5Attr](dset: T): bool =
+  ## Returns true if the dataset or attribute is variable length
+  when T is H5Dataset:
+    result = dset.dtype_class == H5T_VLEN
+  else:
+    result = dset.dtype_c.getTypeClass == H5T_VLEN

--- a/src/nimhdf5/hdf5_json.nim
+++ b/src/nimhdf5/hdf5_json.nim
@@ -14,9 +14,14 @@ type
 
   MemberSizeTable = OrderedTable[string, (int, int, DtypeKind)]
 
-proc `=destroy`(buf: BufferWrapperObj) =
-  buf.cleanup(buf.buf, buf.dtypeID, buf.dspaceID)
-  `=destroy`(buf.buf)
+when (NimMajor, NimMinor, NimPatch) >= (2, 0, 0):
+  proc `=destroy`(buf: BufferWrapperObj) =
+    buf.cleanup(buf.buf, buf.dtypeID, buf.dspaceID)
+    `=destroy`(buf.buf)
+else:
+  proc `=destroy`(buf: var BufferWrapperObj) =
+    buf.cleanup(buf.buf, buf.dtypeID, buf.dspaceID)
+    `=destroy`(buf.buf)
 
 ## Code to read also datasets and groups as JSON:
 


### PR DESCRIPTION
This PR refactors the attributes reading and writing logic. It brings it more in line with the dataset reading and writing logic.

In the future we might fully merge the two and take an argument for the correct HDF5 procedures to call. Meaning that the exact same logic is used to determine the way to prepare the data / convert it to Nim data from given HD5 data.

In addition this enhances the support for more complicated types supported in attributes. Also, all attributes and dataset types can now be read as JSON.

NOTE: For Nim versions below 2.0 it is advised to run with ORC. Otherwise you might get into trouble, due to bad destructor calls (some resources may be closed too early). Generally, while I'm not dropping support for 1.6 fully, it is definitely wonky. Test `tWithDset` ends up in some weird loop in the compiler on 1.6.18. So please just upgrade...