### PR TITLE
Fixes a few more possible sources of crashes

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -3,7 +3,8 @@
   reference type was contained with ~nil~ value
 - fixes a possible crash when trying to write an attribute of string /
   seq type with zero length (simply does not call into the H5 function
-  now; attribute is still created though!)  
+  now; attribute is still created though!)
+- correctly handle ~distinct~ types in ~copyflat~  
 * v0.6.0
 - *PARTIALLY BREAKING*: Nim support for 1.6 is a bit wonky. It's still
   supported, but when running on ~refc~ there seem to be cases where

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.6.1
+- fixes an issue where ~serialize~ (~toH5~) would cause a crash if a
+  reference type was contained with ~nil~ value
+- fixes a possible crash when trying to write an attribute of string /
+  seq type with zero length (simply does not call into the H5 function
+  now; attribute is still created though!)  
 * v0.6.0
 - *PARTIALLY BREAKING*: Nim support for 1.6 is a bit wonky. It's still
   supported, but when running on ~refc~ there seem to be cases where

--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -236,9 +236,10 @@ template writeData(buf: untyped): untyped {.dirty.} =
                    dtypeId,
                    buf)
   elif typeof(buf) is string or typeof(buf) is seq:
-    writeAttribute(attr.attr_id,
-                   dtypeId,
-                   address(buf[0]))
+    if buf.len > 0:
+      writeAttribute(attr.attr_id,
+                     dtypeId,
+                     address(buf[0]))
   else:
     writeAttribute(attr.attr_id,
                    dtypeId,

--- a/src/nimhdf5/copyflat.nim
+++ b/src/nimhdf5/copyflat.nim
@@ -76,11 +76,6 @@ proc copyFlat*[T: SimpleTypes](buf: var Buffer, x: T) =
   var target = buf.data +% buf.offsetOf
   target.copyMem(address(x), size)
 
-proc copyFlat*[T: distinct](buf: var Buffer, x: T) =
-  let size = calcSize(x)
-  var target = buf.data +% buf.offsetOf
-  target.copyMem(address(x), size)
-
 proc copyFlat*[T; N: static int](buf: var Buffer, x: array[N, T]) =
   let size = calcSize(x)
   var target = buf.data +% buf.offsetOf
@@ -102,6 +97,9 @@ proc copyFlat*[T](buf: var Buffer, x: seq[T]) =
   buf.children.add child
   # copy child address
   buf.copyFlat((csize_t(x.len), cast[uint](child.data))) # `hvl_t` like data structure
+
+proc copyFlat*[T: distinct](buf: var Buffer, x: T) =
+  buf.copyFlat(distinctBase(x))
 
 import ./type_utils
 proc copyFlat*[T: object | tuple](buf: var Buffer, x: T) =
@@ -137,6 +135,9 @@ proc fromFlat*[T: SimpleTypes | pointer](x: var T, buf: Buffer) =
   let size = calcSize(x)
   var source = buf.data +% buf.offsetOf
   copyMem(addr(x), source, size)
+
+proc fromFlat*[T: distinct](x: var T, buf: Buffer) =
+  fromFlat(distinctBase(x), buf)
 
 ## XXX: `fromFlat` for fixed length arrays!
 proc fromFlat*[T: array](x: var T, buf: Buffer) =

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -105,7 +105,8 @@ proc toH5*[T: object](h5f: H5File, x: T, name = "", path = "/", exclude: seq[str
 proc toH5*[T: ref object](h5f: H5File, x: T, name = "", path = "/") =
   ## Ref objects are dereferenced and the underlying object stored. Be careful with
   ## nested reference objects that might by cyclic!
-  h5f.toH5(x[], name, path)
+  if x != nil:
+    h5f.toH5(x[], name, path)
 
 proc toH5*[T](x: T,
               file: string,


### PR DESCRIPTION
Fixes two instances where code might crash if the user tries to write empty data & handles `distinct` types better when writing to H5 (in the context of compound data).