### PR TITLE
Fix `DEBUG_HDF5` and some minor leaks, add `fromH5` for `ref objects`

### DIFF
--- a/src/nimhdf5/attributes.nim
+++ b/src/nimhdf5/attributes.nim
@@ -398,6 +398,7 @@ proc readStringArrayAttribute(attr: H5Attr, npoints: hssize_t): seq[string] =
   result = newSeq[string](npoints)
   for i, s in buf:
     result[i] = $s
+    discard H5free_memory(s[0].addr)
 
 proc readStringAttribute(attr: H5Attr): string =
   ## proc to read a string attribute from a H5 file, for an existing
@@ -413,6 +414,7 @@ proc readStringAttribute(attr: H5Attr): string =
     var buf: cstring
     readAttribute(attr, nativeType, buf.addr)
     result = $buf
+    discard H5free_memory(buf.addr)
   else:
     let nativeType = getNativeType(attr.dtype_c)
     let string_len = H5Aget_storage_size(attr.attr_id.id)

--- a/src/nimhdf5/dataspaces.nim
+++ b/src/nimhdf5/dataspaces.nim
@@ -43,7 +43,7 @@ func simple_dataspace*[T: (seq | int)](shape: T, maxshape: seq[int] = @[]): Data
   ## TODO: rewrite this
   var m_maxshape: seq[hsize_t] = parseMaxShape(maxshape)
   withDebug:
-    echo "Creating memory dataspace of shape ", shape
+    debugecho "Creating memory dataspace of shape ", shape
   when T is seq:
     # convert ints to hsize_t (== culonglong) and create mutable copy (need
     # an address to hand it to C function as pointer)

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -725,11 +725,11 @@ proc getNumAttrs*(h5attr: H5Attributes): int =
   if err >= 0:
     # successful
     withDebug:
-      debugEcho "getNumAttrs(): ", h5attr
+      debugEcho "getNumAttrs(): ", $(h5attr[])
     result = int(h5info.num_attrs)
   else:
     withDebug:
-      debugEcho "getNumAttrs(): ", h5attr
+      debugEcho "getNumAttrs(): ", $(h5attr[])
     raise newException(HDF5LibraryError, "Call to HDF5 library failed in `getNumAttr` when reading $#" % $h5attr.parent_name)
 
 proc initH5Attributes*(p_id: sink ParentID, p_name: string = "", p_type: string = ""): H5Attributes =

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -519,7 +519,9 @@ proc getMemberType*(typ: DatatypeID, idx: int): DatatypeID =
 proc getMemberName*(typ: DatatypeID, idx: int): string =
   ## Get the name of the member of the H5T_COMPOUND type at index `idx`
   ## The argument *must* correspond to a compound datatype. We do not check.
-  result = $H5Tget_member_name(typ.id, idx.cuint)
+  var name = H5Tget_member_name(typ.id, idx.cuint)
+  result = $name
+  discard H5free_memory(name[0].addr)
 
 proc getSize*(typ: DatatypeID): int =
   result = H5Tget_size(typ.id).int

--- a/src/nimhdf5/files.nim
+++ b/src/nimhdf5/files.nim
@@ -131,7 +131,7 @@ proc activateSWMR*(h5f: H5File) =
     h5f.accessFlags.incl akWriteSWMR
   elif akWriteSWMR in h5f.accessFlags:
     withDebug:
-      echo "File was already in SWMR mode: ", h5f
+      echo "File was already in SWMR mode: ", $(h5f[])
     discard # already activated
   else:
     raise newException(IOError, "Cannot activate SWMR mode for an input file that misses " &

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -293,13 +293,13 @@ proc fromH5*[T: object](h5f: H5File, res: var T, name = "", path = "/", exclude:
     if field notin exclude:
       h5f.fromH5(val, field, grp)
 
-proc deserializeH5*[T: object](h5f: H5File, name = "", path = "/", exclude: seq[string] = @[]): T =
+proc deserializeH5*[T](h5f: H5File, name = "", path = "/", exclude: seq[string] = @[]): T =
   ## Cannot name it same as `fromH5` because that causes the compiler to get confused. I don't understand,
   ## but with `LikelihoodContext` it ends up calling the `var set[LikelihoodContext]` overload, which does
   ## not make any sense.
   h5f.fromH5(result, name, path, exclude)
 
-proc deserializeH5*[T: object](fname: string, name = "", path = "/", exclude: seq[string] = @[]): T =
+proc deserializeH5*[T](fname: string, name = "", path = "/", exclude: seq[string] = @[]): T =
   ## Cannot name it same as `fromH5` because that causes the compiler to get confused. I don't understand,
   ## but with `LikelihoodContext` it ends up calling the `var set[LikelihoodContext]` overload, which does
   ## not make any sense.

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -292,6 +292,11 @@ proc fromH5*[T: object](h5f: H5File, res: var T, name = "", path = "/", exclude:
   for field, val in fieldPairs(res):
     if field notin exclude:
       h5f.fromH5(val, field, grp)
+proc fromH5*[T: ref object](h5f: H5File, res: var T, name = "", path = "/", exclude: seq[string] = @[]) =
+  bind `/`
+  let grp = path / name
+  res = T()
+  fromH5(h5f, res[], name, path, exclude)
 
 proc deserializeH5*[T](h5f: H5File, name = "", path = "/", exclude: seq[string] = @[]): T =
   ## Cannot name it same as `fromH5` because that causes the compiler to get confused. I don't understand,

--- a/src/nimhdf5/serialize.nim
+++ b/src/nimhdf5/serialize.nim
@@ -180,7 +180,7 @@ proc fromH5*[T: char | string | cstring | bool](h5f: H5File, res: var T, name = 
       res = parseBool(obj.attrs[name, string])
     elif T is char:
       let s = obj.attrs[name, string]
-      doASsert s.len == 0, "Trying to read a char from a string with more than one element."
+      doAssert s.len == 1, "Trying to read a char from a string with more than one element."
       res = s[0]
     elif T is string:
       res = obj.attrs[name, string]

--- a/src/nimhdf5/util.nim
+++ b/src/nimhdf5/util.nim
@@ -18,8 +18,9 @@ template withDebug*(actions: untyped) =
   ## to this template are only performed, if the
   ## -d:DEBUG_HDF5
   ## compiler flag is set.
-  when defined(DEBUG_HDF5):
-    actions
+  block:
+    when defined(DEBUG_HDF5):
+      actions
 
 proc formatName*(name: string): string =
   # this procedure formats a given group / dataset name by prepending


### PR DESCRIPTION
Fixes #76 and #77. 

Also adds `ref object` support for `fromH5` deserialization.