### PR TITLE
Minor attribute fix

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.6.3
+- make ~[]~ for attributes taking a string only for the data type kind
+  to check if the key exist, raise if not.
+  Previously if the attribute hadn't been opened before, the call
+  would fail even if it exists in the file
+- make ~withAttr~ check if the attribute exists in the file
+  first. Previously would fail if it hadn't been opened before
 * v0.6.2
 - fix a small memory leak related to ~cstrings~ not being freed
 - fix the ~-d:DEBUG_HDF5~ option for debug information

--- a/src/nimhdf5/datatypes.nim
+++ b/src/nimhdf5/datatypes.nim
@@ -565,7 +565,8 @@ proc close*(attr: var H5AttrObj) =
         $(attr.attr_id.id) & "!")
     withDebug:
       echo "Closed attribute with status ", err
-    attr.opened = false
+  # close state regardless of object, to make sure we don't leave it open accidentally
+  attr.opened = false
 
 proc close*(attr: H5Attr) = attr[].close()
 

--- a/src/nimhdf5/hdf5_json.nim
+++ b/src/nimhdf5/hdf5_json.nim
@@ -206,7 +206,7 @@ template withAttr*(h5attr: H5Attributes, name: string, actions: untyped) =
   ## copying data type and space and writing the same buffer to a new location.
 
   # read attribute info so that `attr_tab` knows it
-  h5attr.readAttributeInfo(name, closeAttribute = true) # raises KeyError if it does not exist
+  h5attr.readAttributeInfo(name) # raises KeyError if it does not exist
   let attrObj {.inject.} = h5attr.attr_tab[name]
   case attrObj.dtypeAnyKind
   of dkBool:
@@ -290,6 +290,8 @@ template withAttr*(h5attr: H5Attributes, name: string, actions: untyped) =
   else:
     let attr {.inject.} = readJson(attrObj)
     actions
+  # close the attribute again
+  h5attr.attr_tab[name].close()
 
 ## The following JSON related procs are placeholders. We might implement them fully to be
 ## able to write compound data at runtime baesd on JSON data.

--- a/src/nimhdf5/hdf5_json.nim
+++ b/src/nimhdf5/hdf5_json.nim
@@ -204,6 +204,9 @@ template withAttr*(h5attr: H5Attributes, name: string, actions: untyped) =
   ## to get access to the data as Nim objects, but also when copying attributes.
   ## Copying itself can also be done by simply getting the size, reading into a buffer,
   ## copying data type and space and writing the same buffer to a new location.
+
+  # read attribute info so that `attr_tab` knows it
+  h5attr.readAttributeInfo(name, closeAttribute = true) # raises KeyError if it does not exist
   let attrObj {.inject.} = h5attr.attr_tab[name]
   case attrObj.dtypeAnyKind
   of dkBool:

--- a/tests/tattributes.nim
+++ b/tests/tattributes.nim
@@ -32,19 +32,20 @@ proc write_attrs(grp: var H5Group) =
   grp.attrs["ComplexNamedSeqTuple"] = NamedTupSeqComplexAttr
 
 proc assert_attrs(grp: var H5Group) =
-  template readAndCheck(arg, typ, exp): untyped =
+  template readAndCheck(arg, typ, exp, kind): untyped =
     let data = grp.attrs[arg, typ]
     echo "Read: ", data
     doAssert data == exp, "Mismatch, was = " & $data & ", but expected = " & $exp
+    doAssert grp.attrs[arg] == kind, "Mismatch, was = " & $grp.attrs[arg] & ", but expected = " & $kind
 
-  readAndCheck("Time", string, TimeStr)
-  readAndCheck("Counter", int, Counter)
-  readAndCheck("Seq", seq[int], SeqAttr)
-  readAndCheck("SeqStr", seq[string], SeqStrAttr)
-  readAndCheck("Tuple", (float, int), TupAttr)
-  readAndCheck("NamedTuple", tuple[foo: float, bar: int], NamedTupAttr)
-  readAndCheck("ComplexNamedTuple", tuple[foo: string, bar: float], NamedTupStrAttr)
-  readAndCheck("ComplexNamedSeqTuple", seq[tuple[foo: string, bar: float]], NamedTupSeqComplexAttr)
+  readAndCheck("Time", string, TimeStr, dkString)
+  readAndCheck("Counter", int, Counter, dkInt64)
+  readAndCheck("Seq", seq[int], SeqAttr, dkSequence)
+  readAndCheck("SeqStr", seq[string], SeqStrAttr, dkSequence)
+  readAndCheck("Tuple", (float, int), TupAttr, dkObject)
+  readAndCheck("NamedTuple", tuple[foo: float, bar: int], NamedTupAttr, dkObject)
+  readAndCheck("ComplexNamedTuple", tuple[foo: string, bar: float], NamedTupStrAttr, dkObject)
+  readAndCheck("ComplexNamedSeqTuple", seq[tuple[foo: string, bar: float]], NamedTupSeqComplexAttr, dkSequence)
 
   doAssert("Time" in grp.attrs)
   doAssert("NoTime" notin grp.attrs)


### PR DESCRIPTION
Just a couple of minor fixes for some gotchas when reading attributes. Both `[]` taking a string (returning a data type kind) and `withAttr` would previously fail, if the attribute hadn't been read at all. Now we make sure to actually check in the file first.
```
* v0.6.3
- make ~[]~ for attributes taking a string only for the data type kind
  to check if the key exist, raise if not.
  Previously if the attribute hadn't been opened before, the call
  would fail even if it exists in the file
- make ~withAttr~ check if the attribute exists in the file
  first. Previously would fail if it hadn't been opened before
```